### PR TITLE
Remove req and payload from JWT tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ var createGOVUKNotifyToken = require('notifications-node-client');
 var yourServiceID = 123;
 var yourAPIKey = 'SECRET--DO NOT CHECK IN!';
 
-// without payload
-var token = createGOVUKNotifyToken("GET", "/notifications/sms", yourAPIKey, yourServiceID);
+// GET request
+var token = createGOVUKNotifyToken(yourAPIKey, yourServiceID);
 
 request(
   {
@@ -27,8 +27,8 @@ request(
 );
 
 
-// with payload
-var token = createGOVUKNotifyToken("POST", "/notifications/sms", yourAPIKey, yourServiceID, "{content:'Hello world'}");
+// POST request
+var token = createGOVUKNotifyToken(yourAPIKey, yourServiceID);
 
 request(
   {

--- a/authentication.js
+++ b/authentication.js
@@ -2,7 +2,7 @@ var jwt = require('jsonwebtoken');
 var crypto = require('crypto');
 
 
-function create_govuk_notify_token(request_method, request_path, secret, client_id, request_body) {
+function createGovukNotifyToken(request_method, request_path, secret, client_id, request_body) {
 
   return jwt.sign(
     {
@@ -17,4 +17,4 @@ function create_govuk_notify_token(request_method, request_path, secret, client_
 
 }
 
-module.exports = create_govuk_notify_token;
+module.exports = createGovukNotifyToken;

--- a/authentication.js
+++ b/authentication.js
@@ -2,24 +2,18 @@ var jwt = require('jsonwebtoken');
 var crypto = require('crypto');
 
 
-function create_signature(original, secret_key) {
-  return crypto
-    .createHmac('sha256', secret_key)
-    .update(original)
-    .digest('base64');
-}
-
 function create_govuk_notify_token(request_method, request_path, secret, client_id, request_body) {
 
-  var claims = {
-    iss: client_id,
-    iat: Math.round(Date.now() / 1000),
-    req: create_signature(request_method + " " + request_path, secret)
-  };
-
-  if (request_body) claims.pay = create_signature(request_body, secret);
-
-  return jwt.sign(claims, secret, {headers: {typ: "JWT", alg: "HS256"}});
+  return jwt.sign(
+    {
+      iss: client_id,
+      iat: Math.round(Date.now() / 1000)
+    },
+    secret,
+    {
+      headers: {typ: "JWT", alg: "HS256"}
+    }
+  );
 
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "authentication.js",
   "scripts": {

--- a/spec/authentication.js
+++ b/spec/authentication.js
@@ -16,29 +16,14 @@ describe('Authentication', function() {
 
   describe('tokens', function() {
 
-    it('should be generated without a payload', function() {
+    it('can be generated and decoded', function() {
 
       var token = create_govuk_notify_token("POST", "/notifications/sms", "SECRET", 123),
           decoded = jwt.verify(token, 'SECRET');
 
-      expect(token).to.equal('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOjEyMywiaWF0IjoxMjM0NTY3ODkwLCJyZXEiOiJBOVlNVWcrSVk1eDZ0MFN1NUM0Z0t3V3J4YzZXYkZTYWV5RDZWRFUwcWc4PSJ9.v0nbBEimXMrpwH20kX4Xrv6M9I1wZiTQe_Dm8UjPpN0');
+      expect(token).to.equal('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOjEyMywiaWF0IjoxMjM0NTY3ODkwfQ.R9-H_oV7d56Dal9jUAKThrZlo1_LNVqc3LCtY62WQd4');
       expect(decoded.iss).to.equal(123);
       expect(decoded.iat).to.equal(1234567890);
-      expect(decoded.req).to.equal('A9YMUg+IY5x6t0Su5C4gKwWrxc6WbFSaeyD6VDU0qg8=');
-      expect(decoded.pay).to.be.undefined;
-
-    });
-
-    it('should be generated with a payload', function() {
-
-      var token = create_govuk_notify_token("POST", "/notifications/sms", "SECRET", 456, "{'content': 'Hello world'}"),
-          decoded = jwt.verify(token, 'SECRET');
-
-      expect(token).to.equal('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOjQ1NiwiaWF0IjoxMjM0NTY3ODkwLCJyZXEiOiJBOVlNVWcrSVk1eDZ0MFN1NUM0Z0t3V3J4YzZXYkZTYWV5RDZWRFUwcWc4PSIsInBheSI6IkhNcVhIUUtOVHVadUZHWVNGQzJ5T3I2N05VdXIxRmxja01UUHpHWVZVOFU9In0.rMiwF5HzFWdofyhIOJo08oEFRik1a4bqJn9I4K7M5kg');
-      expect(decoded.iss).to.equal(456);
-      expect(decoded.iat).to.equal(1234567890);
-      expect(decoded.req).to.equal('A9YMUg+IY5x6t0Su5C4gKwWrxc6WbFSaeyD6VDU0qg8=');
-      expect(decoded.pay).to.equal('HMqXHQKNTuZuFGYSFC2yOr67NUur1FlckMTPzGYVU8U=');
 
     });
 

--- a/spec/authentication.js
+++ b/spec/authentication.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect,
     MockDate = require('mockdate'),
     jwt = require('jsonwebtoken'),
-    create_govuk_notify_token = require('../authentication.js');
+    createGovukNotifyToken = require('../authentication.js');
 
 
 describe('Authentication', function() {
@@ -18,7 +18,7 @@ describe('Authentication', function() {
 
     it('can be generated and decoded', function() {
 
-      var token = create_govuk_notify_token("POST", "/notifications/sms", "SECRET", 123),
+      var token = createGovukNotifyToken("POST", "/notifications/sms", "SECRET", 123),
           decoded = jwt.verify(token, 'SECRET');
 
       expect(token).to.equal('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOjEyMywiaWF0IjoxMjM0NTY3ODkwfQ.R9-H_oV7d56Dal9jUAKThrZlo1_LNVqc3LCtY62WQd4');


### PR DESCRIPTION
## Remove `req` and `body` from JWT token

We’ve eased up the restrictions on our JWT tokens so that they no longer have to be signed with the request method and path, and the body of the request (for `POST` requests).

This happened here:
alphagov/notifications-api#226

This commit makes similar changes to those we did for the Python client: alphagov/notifications-python-client@277663e

## Change function name from 🐍 to 🐫 case

Because this isn’t Python.

## Bump package version to 2.0.0

Major change because:
- `create_govuk_notify_token` renamed to `createGovukNotifyToken`
- the number of arguments it takes have been reduced