### PR TITLE
Add explicit notify api and expose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/client/api_client.js
+++ b/client/api_client.js
@@ -1,0 +1,76 @@
+var restClient = require('request-promise'),
+    _ = require('underscore'),
+    createGovukNotifyToken = require('../client/authentication.js');
+
+/**
+ * @param urlBase
+ * @param clientId
+ * @param secret
+ *
+ * @constructor
+ */
+function ApiClient(urlBase, clientId, secret) {
+  this.clientId = clientId;
+  this.secret = secret;
+  this.urlBase = urlBase;
+}
+
+/**
+ *
+ * @param {string} requestMethod
+ * @param {string} requestPath
+ * @param {string} secret
+ * @param {string}clientId
+ *
+ * @returns {string}
+ */
+function createToken(requestMethod, requestPath, secret, clientId) {
+  return createGovukNotifyToken(requestMethod, requestPath, secret, clientId)
+}
+
+_.extend(ApiClient.prototype, {
+
+  /**
+   *
+   * @param {string} path
+   *
+   * @returns {Promise}
+   */
+  get: function(path) {
+    var options = {
+      method: 'GET',
+      uri: this.urlBase + path,
+      json: true,
+      resolveWithFullResponse: true,
+      headers: {
+        'Authorization': 'Bearer ' + createToken('GET', path, this.secret, this.clientId)
+      }
+    };
+
+    return restClient(options);
+  },
+
+  /**
+   *
+   * @param {string} path
+   * @param {object} data
+   *
+   * @returns {Promise}
+   */
+  post: function(path, data){
+    var options = {
+      method: 'POST',
+      uri: this.urlBase + path,
+      json: true,
+      body: data,
+      resolveWithFullResponse: true,
+      headers: {
+        'Authorization': 'Bearer ' + createToken('GET', path, this.secret, this.clientId)
+      }
+    };
+
+    return restClient(options);
+  }
+});
+
+module.exports = ApiClient;

--- a/client/authentication.js
+++ b/client/authentication.js
@@ -14,7 +14,6 @@ function createGovukNotifyToken(request_method, request_path, secret, client_id,
       headers: {typ: "JWT", alg: "HS256"}
     }
   );
-
 }
 
 module.exports = createGovukNotifyToken;

--- a/client/notification.js
+++ b/client/notification.js
@@ -1,0 +1,89 @@
+var ApiClient = require('./api_client'),
+  _ = require('underscore');
+
+/**
+ *
+ * @param baseUrl
+ * @param clientId
+ * @param secret
+ *
+ * @constructor
+ */
+function NotifyClient(baseUrl, clientId, secret) {
+  this.apiClient = new ApiClient(baseUrl, clientId, secret);
+}
+
+/**
+ *
+ * @param {String} templateId
+ * @param {String} to
+ * @param {Object} personalisation
+ *
+ * @returns {Object}
+ */
+function createNotificationPayload(templateId, to, personalisation) {
+  var payload = {
+    templateId: templateId,
+    to: to
+  };
+
+  if (!!personalisation) {
+    payload.personalisation = personalisation;
+  }
+
+  return payload;
+}
+
+_.extend(NotifyClient.prototype, {
+  /**
+   * Usage:
+   *
+   * notifyClient = new NotifyClient(urlBase, clientId, secret);
+   *
+   * notifyClient.sendEmail(templateId, email, personalisation)
+   *    .then(function (response) {
+   *       //do stuff with response
+   *     })
+   *     .catch(function (error) {
+   *       //deal with errors here
+   *     });
+   *
+   *
+   * @param {String} templateId
+   * @param {String} emailAddress
+   * @param {Object} personalisation
+   *
+   * @returns {Promise}
+   */
+  sendEmail: function (templateId, emailAddress, personalisation) {
+    return this.apiClient.post('/notifications/email',
+      createNotificationPayload(templateId, emailAddress, personalisation));
+  },
+
+  /**
+   *
+   * @param {String} templateId
+   * @param {String} phoneNumber
+   * @param {Object} personalisation
+   *
+   * @returns {Promise}
+   */
+  sendSms: function (templateId, phoneNumber, personalisation) {
+    return this.apiClient.post('/notifications/sms',
+      createNotificationPayload(templateId, phoneNumber, personalisation));
+  },
+
+  /**
+   *
+   * @param {String} notificationId
+   *
+   * @returns {Promise}
+   */
+  getNotificationById: function(notificationId) {
+    return this.apiClient.get('/notifications/' + notificationId);
+  }
+});
+
+module.exports = {
+  NotifyClient: NotifyClient
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+var NotifyClient = require("./client/notification.js");
+
+module.exports = {
+  NotifyClient: NotifyClient
+};

--- a/package.json
+++ b/package.json
@@ -1,20 +1,25 @@
 {
   "name": "notifications-node-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "GOV.UK Notify Node.js client ",
-  "main": "authentication.js",
+  "main": "index.js",
   "scripts": {
-    "test": "mocha spec/authentication.js"
+    "test": "mocha spec/*.js"
   },
   "author": "GDS developers",
   "license": "MIT",
   "dependencies": {
     "crypto": "0.0.3",
-    "jsonwebtoken": "5.5.4"
+    "jsonwebtoken": "5.5.4",
+    "request": "^2.73.0",
+    "request-promise": "^4.0.1",
+    "restler": "3.4.0",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "3.4.1",
     "mocha": "2.3.4",
-    "mockdate": "1.0.3"
+    "mockdate": "1.0.3",
+    "nock": "8.0.0"
   }
 }

--- a/spec/api_client.js
+++ b/spec/api_client.js
@@ -1,0 +1,64 @@
+var expect = require('chai').expect,
+  ApiClient = require('../client/api_client.js'),
+  nock = require('nock'),
+  createGovukNotifyToken = require('../client/authentication.js');
+
+
+describe('api client', function () {
+
+  it('should make a get request with correct jwt token', function (done) {
+
+    var urlBase = 'http://base',
+      path = '/email',
+      body = {
+        'body': 'body text'
+      },
+      clientId = 123,
+      secret = 'SECRET',
+      apiClient = new ApiClient(urlBase, clientId, secret);
+
+    nock(urlBase, {
+      reqheaders: {
+        'Authorization': 'Bearer ' + createGovukNotifyToken('GET', path, secret, clientId)
+      }
+    })
+      .get(path)
+      .reply(200, body);
+
+    apiClient = new ApiClient(urlBase, clientId, secret);
+    apiClient.get(path)
+      .then(function (response) {
+        expect(response.body).to.deep.equal(body);
+        done();
+    });
+  });
+
+  it('should make a post request with correct jwt token', function (done) {
+
+    var urlBase = 'http://base',
+      path = '/email',
+      data = {
+        'data': 'qwjjs'
+      },
+      clientId = 123,
+      secret = 'SECRET',
+      apiClient = new ApiClient(urlBase, clientId, secret);
+
+
+    nock(urlBase, {
+      reqheaders: {
+        'Authorization': 'Bearer ' + createGovukNotifyToken('POST', path, secret, clientId)
+      }
+    })
+      .post(path, data)
+      .reply(200, {"hooray": "bkbbk"});
+
+    apiClient = new ApiClient(urlBase, clientId, secret);
+    apiClient.post(path, data)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+    });
+  });
+
+});

--- a/spec/authentication.js
+++ b/spec/authentication.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect,
     MockDate = require('mockdate'),
     jwt = require('jsonwebtoken'),
-    createGovukNotifyToken = require('../authentication.js');
+    createGovukNotifyToken = require('../client/authentication.js');
 
 
 describe('Authentication', function() {

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -1,0 +1,90 @@
+var expect = require('chai').expect, NotifyClient = require('../client/notification.js').NotifyClient,
+    nock = require('nock'),
+    createGovukNotifyToken = require('../client/authentication.js');
+
+
+describe('notification api', function() {
+
+    it('should send an email', function(done) {
+
+        var urlBase = 'http://base',
+          email = 'dom@example.com',
+          templateId = '123',
+          personalisation = {foo: 'bar'},
+          data = {
+              templateId: templateId,
+              to: email,
+              personalisation: personalisation
+          },
+          notifyClient,
+          clientId = 123,
+          secret = 'SECRET';
+
+        nock(urlBase, {
+            reqheaders: {
+                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/notifications/email', secret, clientId)
+            }})
+            .post('/notifications/email', data)
+            .reply(200, {"hooray": "bkbbk"});
+
+        notifyClient = new NotifyClient(urlBase, clientId, secret);
+        notifyClient.sendEmail(templateId, email, personalisation)
+          .then(function (response) {
+            expect(response.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('should send an sms', function(done) {
+
+        var urlBase = 'http://base',
+          phoneNo = '07525755555',
+          templateId = '123',
+          personalisation = {foo: 'bar'},
+          data = {
+              templateId: templateId,
+              to: phoneNo,
+              personalisation: personalisation
+          },
+          notifyClient,
+          clientId = 123,
+          secret = 'SECRET';
+
+        nock(urlBase, {
+            reqheaders: {
+                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/notifications/email', secret, clientId)
+            }})
+          .post('/notifications/sms', data)
+          .reply(200, {"hooray": "bkbbk"});
+
+        notifyClient = new NotifyClient(urlBase, clientId, secret);
+        notifyClient.sendSms(templateId, phoneNo, personalisation)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+    });
+
+    it('should get notification by id', function(done) {
+
+        var urlBase = 'http://base',
+          notificationId = 'wfdfdgf',
+          notifyClient,
+          clientId = 123,
+          secret = 'SECRET';
+
+        nock(urlBase, {
+            reqheaders: {
+                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/notifications/email', secret, clientId)
+            }})
+          .get('/notifications/' + notificationId)
+          .reply(200, {"hooray": "bkbbk"});
+
+        notifyClient = new NotifyClient(urlBase, clientId, secret);
+        notifyClient.getNotificationById(notificationId)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+    });
+});


### PR DESCRIPTION
To make the library more useful for integrators, this adds client/notification.js which defines the standard notify api (with reference to  Notify's other client libraries).

Exposed api currently consists of 3 methods: sendEmail, sendSms, getNotificationById.This can be fleshed out further in future. Basic tests included. These could also be expanded.