### PR TITLE
Fix broken client initialisation

### DIFF
--- a/client/notification.js
+++ b/client/notification.js
@@ -9,8 +9,11 @@ var ApiClient = require('./api_client'),
  *
  * @constructor
  */
-function NotifyClient(baseUrl, serviceId, apiKeyId) {
-  this.apiClient = new ApiClient(baseUrl, serviceId, apiKeyId);
+function NotifyClient() {
+  this.apiClient = new (Function.prototype.bind.apply(
+      ApiClient,
+      [null].concat(Array.prototype.slice.call(arguments))
+  ));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The wrapper was always passing three arguments to the constructor. eg `new NotifyClient('abc123')` would result in `ApiClient` getting called with (`abc123`, `undefined`, `undefined`).

Because we count the arguments in `ApiClient` to determine what they mean this completely broke the client, because it was trying to use the API key as the base url, `undefined` as the API key and `undefined` as the service ID.

Luckily we hadn’t published the client, so this didn’t impact any actual users.

This commit does some Javascript gymnastics to always call the constructor with the same number of arguments that the wrapper is given.

Technique taken from: http://stackoverflow.com/a/8843181/147318

> A bit of explanation: We need to run new on a function that takes a limited number of arguments. The bind method allows us to do it like so:
>
> ```
> var f = Cls.bind(anything, arg1, arg2, ...);
> result = new f();
> ```

The `slice` call is necessary because `arguments` isn’t a proper array.

***

Tested locally with a prototype using this client.