### PR TITLE
Add new template get/post methods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
-## [3.0.0] - 2016-12-16
+## [3.1.0] - 2017-05-10
+
 ### Changed
+
+* Added new methods for managing templates:
+    * `getTemplateById` - retrieve a single template
+    * `getTemplateByIdAndVersion` - retrieve a specific version for a desired template
+    * `getAllTemplates` - retrieve all templates (can filter by type)
+    * `previewTemplateById` - preview a template with personalisation applied
+
+* Update README to describe how to catch errors
+
+## [3.0.0] - 2016-12-16
+
+### Changed
+
 * Using v2 of the notification-api.
 
 * Update to `notifyClient.sendSms()`:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ npm install notifications-node-client
 ## Getting started
 ```javascript
 var NotifyClient = require('notifications-node-client').NotifyClient,
-
-notifyClient = new NotifyClient(apiKey);
+	notifyClient = new NotifyClient(apiKey);
 ```
 
 Generate an API key by logging in to

--- a/README.md
+++ b/README.md
@@ -721,3 +721,19 @@ personalisation={
 ```
 
 Otherwise the parameter can be omitted or `undefined` can be passed in its place.
+
+## Tests
+
+There are unit and integration tests that can be run to test functionality of the client. You will need to have the relevant environment variables sourced to run the tests.
+
+To run the unit tests:
+
+```sh
+npm test
+```
+
+To run the integration tests:
+
+```sh
+npm test --integration
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ the _API integration_ page.
 ### Text message
 
 ```javascript
-notifyClient.sendSms(templateId, phoneNumber, personalisation, reference);
+notifyClient
+	.sendSms(templateId, phoneNumber, personalisation, reference)
+	.then((response) => { })
+	.catch((err) => {})
+;
 ```
 
 <details>
@@ -31,7 +35,7 @@ notifyClient.sendSms(templateId, phoneNumber, personalisation, reference);
 Response
 </summary>
 
-If the request is successful, `response` will be an `Object`:
+If the request is successful, `response` will be a `Dictionary`:
 
 ```javascript
 {
@@ -50,12 +54,12 @@ If the request is successful, `response` will be an `Object`:
 }
 ```
 
-Otherwise the client will raise a `StatusCodeError`:
+Otherwise the client will return an error `err`:
 <table>
 <thead>
 <tr>
-<th>`error.status_code`</th>
-<th>`error.message`</th>
+<th>`err.error.status_code`</th>
+<th>`err.error.errors`</th>
 </tr>
 </thead>
 <tbody>
@@ -119,7 +123,11 @@ Otherwise the client will raise a `StatusCodeError`:
 ### Email
 
 ```javascript
-notifyClient.sendEmail(templateId, emailAddress, personalisation, reference);
+notifyClient
+	.sendEmail(templateId, emailAddress, personalisation, reference);
+    .then((response) => { })
+    .catch((err) => {})
+;
 ```
 
 <details>
@@ -127,7 +135,7 @@ notifyClient.sendEmail(templateId, emailAddress, personalisation, reference);
 Response
 </summary>
 
-If the request is successful, `response` will be an `Object`:
+If the request is successful, `response` will be a `Dictionary`:
 
 ```javascript
 {
@@ -147,12 +155,12 @@ If the request is successful, `response` will be an `Object`:
 }
 ```
 
-Otherwise the client will raise a `StatusCodeError`:
+Otherwise the client will return an error `err`:
 <table>
 <thead>
 <tr>
-<th>`error.status_code`</th>
-<th>`error.message`</th>
+<th>`err.error.status_code`</th>
+<th>`err.error.errors`</th>
 </tr>
 </thead>
 <tbody>
@@ -240,7 +248,11 @@ An optional identifier you generate if you don’t want to use Notify’s `id`. 
 
 ## Get the status of one message
 ```javascript
-notifyClient.getNotificationById(notificationId)
+notifyClient
+	.getNotificationById(notificationId)
+	.then((response) => { })
+	.catch((err) => {})
+;
 ```
 
 <details>
@@ -248,7 +260,7 @@ notifyClient.getNotificationById(notificationId)
 Response
 </summary>
 
-If the request is successful, `response` will be an `Object`:
+If the request is successful, `response` will be a `Dictionary`:
 
 ```javascript
 {
@@ -277,12 +289,12 @@ If the request is successful, `response` will be an `Object`:
 }
 ```
 
-Otherwise the client will raise a `StatusCodeError`:
+Otherwise the client will return an error `err`:
 <table>
 <thead>
 <tr>
-<th>`error.status_code`</th>
-<th>`error.message`</th>
+<th>`err.error.status_code`</th>
+<th>`err.error.errors`</th>
 </tr>
 </thead>
 <tbody>
@@ -318,7 +330,11 @@ Otherwise the client will raise a `StatusCodeError`:
 
 ## Get the status of all messages
 ```javascript
-notifyClient.getNotifications(templateType, status, reference, olderThan)
+notifyClient
+	.getNotifications(templateType, status, reference, olderThan)
+	.then((response) => { })
+	.catch((err) => {})
+;
 ```
 
 <details>
@@ -326,7 +342,7 @@ notifyClient.getNotifications(templateType, status, reference, olderThan)
 Response
 </summary>
 
-If the request is successful, `response` will be an `Object`:
+If the request is successful, `response` will be a `Dictionary`:
 
 ```javascript
 { "notifications":
@@ -361,12 +377,12 @@ If the request is successful, `response` will be an `Object`:
 }
 ```
 
-Otherwise the client will raise a `StatusCodeError`:
+Otherwise the client will return an error `err`:
 <table>
 <thead>
 <tr>
-<th>`error.status_code`</th>
-<th>`error.message`</th>
+<th>`err.error.status_code`</th>
+<th>`err.error.errors`</th>
 </tr>
 </thead>
 <tbody>
@@ -430,3 +446,278 @@ This is the `reference` you gave at the time of sending the notification. This c
 #### `olderThan`
 
 If omitted all messages are returned. Otherwise you can filter to retrieve all notifications older than the given notification `id`.
+
+## Get a template by ID
+
+```javascript
+notifyClient
+    .getTemplateById(templateId)
+    .then((response) => { })
+    .catch((err) => {})
+;
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+If the request is successful, `response` will be a `Dictionary`:
+
+```javascript
+{
+    "id": "template_id",
+    "type": "sms|email|letter",
+    "created_at": "created at",
+    "updated_at": "updated at",
+    "version": "version",
+    "created_by": "someone@example.com",
+    "body": "body",
+    "subject": "null|email_subject"
+}
+```
+
+Otherwise the client will return an error `err`:
+<table>
+<thead>
+<tr>
+<th>`err.error.status_code`</th>
+<th>`err.error.errors`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>404</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+]}
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+
+#### `templateId`
+
+Find by clicking **API info** for the template you want to send.
+
+## Get a template by ID and version
+
+```javascript
+notifyClient
+    .getTemplateByIdAndVersion(templateId, version)
+    .then((response) => { })
+    .catch((err) => {})
+;
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+If the request is successful, `response` will be a `Dictionary`:
+
+```javascript
+{
+    "id": "template_id",
+    "type": "sms|email|letter",
+    "created_at": "created at",
+    "updated_at": "updated at",
+    "version": "version",
+    "created_by": "someone@example.com",
+    "body": "body",
+    "subject": "null|email_subject"
+}
+```
+
+Otherwise the client will return an error `err`:
+<table>
+<thead>
+<tr>
+<th>`err.error.status_code`</th>
+<th>`err.error.errors`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>404</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+]}
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+#### `templateId`
+
+Find by clicking **API info** for the template you want to send.
+
+#### `version`
+
+The version number of the template
+
+## Get all templates
+
+```javascript
+notifyClient
+    .getAllTemplates(templateType)
+    .then((response) => { })
+    .catch((err) => {})
+;
+```
+_This will return the latest version for each template_
+
+<details>
+<summary>
+Response
+</summary>
+
+If the request is successful, `response` will be a `Dictionary`:
+
+```javascript
+{
+    "templates" : [
+        {
+            "id": "template_id",
+            "type": "sms|email|letter",
+            "created_at": "created at",
+            "updated_at": "updated at",
+            "version": "version",
+            "created_by": "someone@example.com",
+            "body": "body",
+            "subject": "null|email_subject"
+        },
+        {
+            ... another template
+        }
+    ]
+}
+```
+
+If no templates exist for a template type or there no templates for a service, the `response` will be a `Dictionary` with an empty `templates` list element:
+
+```javascript
+{
+    "templates" : []
+}
+```
+
+</details>
+
+### Arguments
+
+#### `templateType`
+
+If omitted all messages are returned. Otherwise you can filter by:
+
+* `email`
+* `sms`
+* `letter`
+
+
+## Generate a preview template
+
+```javascript
+personalisation = { "foo": "bar" };
+notifyClient
+    .previewTemplateById(templateId, personalisation)
+    .then((response) => { })
+    .catch((err) => {})
+;
+```
+
+<details>
+<summary>
+Response
+</summary>
+
+If the request is successful, `response` will be a `Dictionary`:
+
+```javascript
+{
+    "id": "notify_id",
+    "type": "sms|email|letter",
+    "version": "version",
+    "body": "Hello bar" // with substitution values,
+    "subject": "null|email_subject"
+}
+```
+
+Otherwise the client will return an error `err`:
+<table>
+<thead>
+<tr>
+<th>`err.error.status_code`</th>
+<th>`err.error.errors`</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<pre>400</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "BadRequestError",
+    "message": "Missing personalisation: [name]"
+]}
+</pre>
+</td>
+</tr>
+<tr>
+<td>
+<pre>404</pre>
+</td>
+<td>
+<pre>
+[{
+    "error": "NoResultFound",
+    "message": "No result found"
+]}
+</pre>
+</td>
+</tr>
+</tbody>
+</table>
+</details>
+
+### Arguments
+
+
+#### `templateId`
+
+Find by clicking **API info** for the template you want to send.
+
+#### `personalisation`
+
+If a template has placeholders you need to provide their values. For example:
+
+```javascript
+personalisation={
+    'first_name': 'Amala',
+    'reference_number': '300241',
+}
+```
+
+Otherwise the parameter can be omitted or `undefined` can be passed in its place.

--- a/client/notification.js
+++ b/client/notification.js
@@ -83,6 +83,14 @@ function buildGetAllNotificationsQuery(templateType, status, reference, olderTha
     return [key, payload[key]].map(encodeURIComponent).join("=");
   }).join("&");
 
+  return buildQueryStringFromDict(payload);
+}
+
+function buildQueryStringFromDict(dictionary) {
+  var queryString = Object.keys(dictionary).map(function(key) {
+    return [key, dictionary[key]].map(encodeURIComponent).join("=");
+  }).join("&");
+
   return queryString ? '?' + queryString : '';
 }
 
@@ -149,7 +157,64 @@ _.extend(NotifyClient.prototype, {
    */
   getNotifications: function(templateType, status, reference, olderThanId) {
     return this.apiClient.get('/v2/notifications' + buildGetAllNotificationsQuery(templateType, status, reference, olderThanId));
+  },
+
+  /**
+   *
+   * @param {String} templateId
+   *
+   * @returns {Promise}
+   */
+  getTemplateById: function(templateId) {
+    return this.apiClient.get('/v2/template/' + templateId);
+  },
+
+  /**
+   *
+   * @param {String} templateId
+   * @param {Integer} version
+   *
+   * @returns {Promise}
+   */
+  getTemplateByIdAndVersion: function(templateId, version) {
+    return this.apiClient.get('/v2/template/' + templateId + '/version/' + version);
+  },
+
+  /**
+   *
+   * @param {String} type
+   *
+   * @returns {Promise}
+   */
+  getAllTemplates: function(templateType) {
+    templateQuery = ''
+
+    if (templateType) {
+      templateQuery = '?type=' + templateType;
+    }
+
+    return this.apiClient.get('/v2/templates' + templateQuery);
+  },
+
+  /**
+   *
+   * @param {String} templateId
+   * @param {Dictionary} personalisation
+   *
+   * @returns {Promise}
+   */
+  previewTemplateById: function(templateId, personalisation) {
+
+    payload = {}
+
+    if (!!personalisation) {
+      payload.personalisation = personalisation;
+    }
+
+    return this.apiClient.post('/v2/template/' + templateId +  '/preview', payload);
   }
+
+
 });
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/spec/integration/schemas/v2/GET_template_by_id.json
+++ b/spec/integration/schemas/v2/GET_template_by_id.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "GET template by id schema response",
+    "type": "object",
+    "title": "reponse v2/template",
+    "properties": {
+        "id": {"$ref": "definitions.json#/uuid"},
+        "type": {"enum": ["sms", "email", "letter"] },
+        "created_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Date+time created"
+        },
+        "updated_at": {
+            "format": "date-time",
+            "type": ["string", "null"],
+            "description": "Date+time updated"
+        },
+        "created_by": {"type": "string"},
+        "version": {"type": "integer"},
+        "body": {"type": "string"},
+        "subject": {"type": ["string", "null"]}
+    },
+    "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body"]
+}

--- a/spec/integration/schemas/v2/GET_templates_response.json
+++ b/spec/integration/schemas/v2/GET_templates_response.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "GET response schema when getting all templates",
+    "type": "object",
+    "properties": {
+        "templates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "$ref": "definitions.json#/template"
+            }
+        }
+    },
+    "required": ["templates"]
+}

--- a/spec/integration/schemas/v2/POST_template_preview.json
+++ b/spec/integration/schemas/v2/POST_template_preview.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "POST template preview schema response",
+    "type": "object",
+    "title": "reponse v2/template/{id}/preview",
+    "properties": {
+        "id": {"$ref": "definitions.json#/uuid"},
+        "type": {"enum": ["sms", "email", "letter"] },
+        "version": {"type": "integer"},
+        "body": {"type": "string"},
+        "subject": {"type": ["string", "null"]}
+    },
+    "required": ["id", "type", "version", "body"]
+}

--- a/spec/integration/schemas/v2/definitions.json
+++ b/spec/integration/schemas/v2/definitions.json
@@ -17,7 +17,7 @@
         "version": {"type": "integer"},
         "uri": {"type": "string"}
     },
-    "required": ["id", "version", "uri"]
+    "required": ["id", "version"]
   },
   "email_content": {
     "type": "object",

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -20,6 +20,8 @@ describer('notification api with a live service', () => {
   const clientRef = 'client-ref';
   const email = process.env.FUNCTIONAL_TEST_EMAIL;
   const phoneNumber = process.env.FUNCTIONAL_TEST_NUMBER;
+  const smsTemplateId = process.env.SMS_TEMPLATE_ID;
+  const emailTemplateId = process.env.EMAIL_TEMPLATE_ID;
 
   beforeEach(() => {
 
@@ -32,77 +34,144 @@ describer('notification api with a live service', () => {
 
   });
 
-  describe('should send', () => {
+  describe('notifications', () => {
 
-    it('email', () => {
-
-      var post_notification_return_email_json = require('./schemas/v2/POST_notification_email_response.json');
-      const emailTemplateId = process.env.EMAIL_TEMPLATE_ID;
+    it('send email notification', () => {
+      var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json');
       return notifyClient.sendEmail(emailTemplateId, email, personalisation, clientRef).then((response) => {
         response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(post_notification_return_email_json);
+        expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
         response.body.content.subject.should.equal('Functional Tests are good');
         response.body.reference.should.equal(clientRef);
         emailNotificationId = response.body.id;
-      });
-
+      })
     });
 
-    it('sms', () => {
-
-      var post_notification_return_sms_json = require('./schemas/v2/POST_notification_sms_response.json');
-      const smsTemplateId = process.env.SMS_TEMPLATE_ID;
+    it('send sms notification', () => {
+      var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json');
       return notifyClient.sendSms(smsTemplateId, phoneNumber, personalisation).then((response) => {
         response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(post_notification_return_sms_json);
+        expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
         smsNotificationId = response.body.id;
       });
-
     });
 
-  });
+    var getNotificationJson = require('./schemas/v2/GET_notification_response.json');
+    var getNotificationsJson = require('./schemas/v2/GET_notifications_response.json');
 
-  describe('should retrieve', () => {
-
-    var notificationJson = require('./schemas/v2/GET_notification_response.json');
-
-    it('email by id', () => {
-
+    it('get email notification by id', () => {
       should.exist(emailNotificationId)
       return notifyClient.getNotificationById(emailNotificationId).then((response) => {
         response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(notificationJson);
+        expect(response.body).to.be.jsonSchema(getNotificationJson);
         response.body.type.should.equal('email');
         response.body.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
         response.body.subject.should.equal('Functional Tests are good');
       });
-
     });
 
-    it('sms by id', () => {
-
+    it('get sms notification by id', () => {
       should.exist(smsNotificationId)
       return notifyClient.getNotificationById(smsNotificationId).then((response) => {
         response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(notificationJson);
+        expect(response.body).to.be.jsonSchema(getNotificationJson);
         response.body.type.should.equal('sms');
         response.body.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
       });
-
     });
 
-    it('all notifications', () => {
-
-      var notificationJson = require('./schemas/v2/GET_notification_response.json');
-      chai.tv4.addSchema('notification.json', notificationJson);
-      var get_notifications_return_json = require('./schemas/v2/GET_notifications_response.json');
+    it('get all notifications', () => {
+      chai.tv4.addSchema('notification.json', getNotificationJson);
       return notifyClient.getNotifications().then((response) => {
         response.should.have.property('statusCode', 200);
-        expect(response.body).to.be.jsonSchema(get_notifications_return_json);
+        expect(response.body).to.be.jsonSchema(getNotificationsJson);
       });
+    });
 
+  });
+
+  describe('templates', () => {
+
+    var getTemplateJson = require('./schemas/v2/GET_template_by_id.json');
+    var getTemplatesJson = require('./schemas/v2/GET_templates_response.json');
+    var postTemplatePreviewJson = require('./schemas/v2/POST_template_preview.json');
+
+    it('get sms template by id', () => {
+      return notifyClient.getTemplateById(smsTemplateId).then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(getTemplateJson);
+        should.not.exist(response.body.subject);
+      });
+    });
+
+    it('get email template by id', () => {
+      return notifyClient.getTemplateById(emailTemplateId).then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(getTemplateJson);
+        response.body.body.should.equal('Hello ((name))\n\nFunctional test help make our world a better place');
+        response.body.subject.should.equal('Functional Tests are good');
+      });
+    });
+
+    it('get sms template by id and version', () => {
+      return notifyClient.getTemplateByIdAndVersion(smsTemplateId, 1).then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(getTemplateJson);
+        should.not.exist(response.body.subject);
+        response.body.version.should.equal(1);
+      });
+    });
+
+    it('get email template by id and version', () => {
+      return notifyClient.getTemplateByIdAndVersion(emailTemplateId, 1).then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(getTemplateJson);
+        response.body.version.should.equal(1);
+      });
+    });
+
+    it('get all templates', () => {
+      return notifyClient.getAllTemplates().then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(getTemplatesJson);
+      });
+    });
+
+    it('get sms templates', () => {
+      return notifyClient.getAllTemplates('sms').then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(getTemplatesJson);
+      });
+    });
+
+    it('get email templates', () => {
+      return notifyClient.getAllTemplates('email').then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(getTemplatesJson);
+      });
+    });
+
+    it('preview sms template', () => {
+      var personalisation = { "name": "Foo" }
+      return notifyClient.previewTemplateById(smsTemplateId, personalisation).then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(postTemplatePreviewJson);
+        response.body.type.should.equal('sms');
+        should.not.exist(response.body.subject);
+      });
+    });
+
+    it('preview email template', () => {
+      var personalisation = { "name": "Foo" }
+      return notifyClient.previewTemplateById(emailTemplateId, personalisation).then((response) => {
+        response.statusCode.should.equal(200);
+        expect(response.body).to.be.jsonSchema(postTemplatePreviewJson);
+        response.body.type.should.equal('email');
+        should.exist(response.body.subject);
+        console.log(response.body)
+      });
     });
 
   });

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -170,7 +170,6 @@ describer('notification api with a live service', () => {
         expect(response.body).to.be.jsonSchema(postTemplatePreviewJson);
         response.body.type.should.equal('email');
         should.exist(response.body.subject);
-        console.log(response.body)
       });
     });
 

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -2,62 +2,68 @@ var expect = require('chai').expect, NotifyClient = require('../client/notificat
     nock = require('nock'),
     createGovukNotifyToken = require('../client/authentication.js');
 
+const baseUrl = 'http://localhost';
+const serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1';
+const apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
+
+function getNotifyClient() {
+    var baseUrl = 'http://localhost';
+    var notifyClient = new NotifyClient(baseUrl, serviceId, apiKeyId);
+    return notifyClient;
+}
+
+function getNotifyAuthNock() {
+    var notifyNock = nock(baseUrl, {
+        reqheaders: {
+            'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
+        }
+    })
+    return notifyNock;
+}
 
 describe('notification api', function() {
 
+    var notifyClient = getNotifyClient();
+    var notifyAuthNock = getNotifyAuthNock();
+
     it('should send an email', function(done) {
 
-        var urlBase = 'http://localhost',
-          email = 'dom@example.com',
+        var email = 'dom@example.com',
           templateId = '123',
           personalisation = {foo: 'bar'},
           data = {
               template_id: templateId,
               email_address: email,
               personalisation: personalisation
-          },
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
+          };
 
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/email', apiKeyId, serviceId)
-            }})
-            .post('/v2/notifications/email', data)
-            .reply(200, {"hooray": "bkbbk"});
+        notifyAuthNock
+          .post('/v2/notifications/email', data)
+          .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.sendEmail(templateId, email, personalisation)
           .then(function (response) {
             expect(response.statusCode).to.equal(200);
             done();
         });
+
     });
 
     it('should send an sms', function(done) {
 
-        var urlBase = 'http://localhost',
-          phoneNo = '07525755555',
+        var phoneNo = '07525755555',
           templateId = '123',
           personalisation = {foo: 'bar'},
           data = {
               template_id: templateId,
               phone_number: phoneNo,
               personalisation: personalisation
-          },
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
+          };
 
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/email', apiKeyId, serviceId)
-            }})
+        notifyAuthNock
           .post('/v2/notifications/sms', data)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.sendSms(templateId, phoneNo, personalisation)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
@@ -67,20 +73,13 @@ describe('notification api', function() {
 
     it('should get notification by id', function(done) {
 
-        var urlBase = 'http://localhost',
-          notificationId = 'wfdfdgf',
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
+        var baseUrl = 'http://localhost',
+          notificationId = 'wfdfdgf';
 
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-            }})
+        notifyAuthNock
           .get('/v2/notifications/' + notificationId)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.getNotificationById(notificationId)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
@@ -90,19 +89,10 @@ describe('notification api', function() {
 
     it('should get all notifications', function(done) {
 
-        var urlBase = 'http://localhost',
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
-
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-            }})
+        notifyAuthNock
           .get('/v2/notifications')
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.getNotifications()
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
@@ -112,19 +102,12 @@ describe('notification api', function() {
 
     it('should get all notifications with a reference', function(done) {
 
-        var urlBase = 'http://localhost',
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
-          reference = 'myref'
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-            }})
+        var reference = 'myref'
+
+        notifyAuthNock
           .get('/v2/notifications?reference=' + reference)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.getNotifications(undefined, undefined, reference)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
@@ -134,20 +117,12 @@ describe('notification api', function() {
 
     it('should get all failed notifications', function(done) {
 
-        var urlBase = 'http://localhost',
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
-          status = 'failed';
+        var status = 'failed';
 
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-            }})
+        notifyAuthNock
           .get('/v2/notifications?status=' + status)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.getNotifications(undefined, 'failed')
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
@@ -157,21 +132,13 @@ describe('notification api', function() {
 
     it('should get all failed sms notifications', function(done) {
 
-        var urlBase = 'http://localhost',
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
-          templateType = 'sms'
+        var templateType = 'sms'
           status = 'failed';
 
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-            }})
+        notifyAuthNock
           .get('/v2/notifications?template_type=' + templateType + '&status=' + status)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.getNotifications(templateType, status)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
@@ -181,22 +148,14 @@ describe('notification api', function() {
 
     it('should get all delivered sms notifications with a reference', function(done) {
 
-        var urlBase = 'http://localhost',
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
-          templateType = 'sms'
+        var templateType = 'sms'
           status = 'delivered';
           reference = 'myref'
 
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-            }})
+        notifyAuthNock
           .get('/v2/notifications?template_type=' + templateType + '&status=' + status + '&reference=' + reference)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.getNotifications(templateType, status, reference)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
@@ -206,19 +165,12 @@ describe('notification api', function() {
 
     it('should get all failed email notifications with a reference older than a given notification', function(done) {
 
-        var urlBase = 'http://localhost',
-          notifyClient,
-          serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1',
-          apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
-          templateType = 'sms';
+        var templateType = 'sms';
           status = 'delivered';
           reference = 'myref';
           olderThanId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
 
-        nock(urlBase, {
-            reqheaders: {
-                'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-            }})
+        notifyAuthNock
           .get('/v2/notifications?template_type=' + templateType +
                '&status=' + status +
                '&reference=' + reference +
@@ -226,8 +178,103 @@ describe('notification api', function() {
               )
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient = new NotifyClient(urlBase, serviceId, apiKeyId);
         notifyClient.getNotifications(templateType, status, reference, olderThanId)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+    });
+
+    it('should get template by id', function(done) {
+
+        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+
+        notifyAuthNock
+          .get('/v2/template/' + templateId)
+          .reply(200, {"foo": "bar"});
+
+        notifyClient.getTemplateById(templateId)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+
+    });
+
+    it('should get template by id and version', function(done) {
+
+        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+          version = 10;
+
+        notifyAuthNock
+          .get('/v2/template/' + templateId + '/version/' + version)
+          .reply(200, {"foo": "bar"});
+
+        notifyClient.getTemplateByIdAndVersion(templateId, version)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+
+    });
+
+    it('should get all templates with unspecified template type', function(done) {
+
+        notifyAuthNock
+          .get('/v2/templates')
+          .reply(200, {"foo": "bar"});
+
+        notifyClient.getAllTemplates()
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+
+    });
+
+    it('should get all templates with unspecified template type', function(done) {
+
+        var templateType = 'sms'
+
+        notifyAuthNock
+          .get('/v2/templates?type=' + templateType)
+          .reply(200, {"foo": "bar"});
+
+        notifyClient.getAllTemplates(templateType)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+
+    });
+
+    it('should preview template by id with personalisation', function(done) {
+
+        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+          payload = { "name": "Foo" }
+          expectedPersonalisation = { "personalisation" : payload };
+
+        notifyAuthNock
+          .post('/v2/template/' + templateId + '/preview', expectedPersonalisation)
+          .reply(200, {"foo": "bar"});
+
+        notifyClient.previewTemplateById(templateId, payload)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+
+    });
+
+    it('should preview template by id without personalisation', function(done) {
+
+        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+
+        notifyAuthNock
+          .post('/v2/template/' + templateId + '/preview')
+          .reply(200, {"foo": "bar"});
+
+        notifyClient.previewTemplateById(templateId)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
               done();


### PR DESCRIPTION
This adds new methods for template retrieval and preview. Additionally the `README` has been updated to demonstrate how to catch errors.

## Summary

The following template methods (with tests) have been added:

1) `getTemplateById` - retrieve a single template
2) `getTemplateByIdAndVersion` - retrieve a specific version for a desired template
3) `getAllTemplates` - retrieve all templates (can filter by type)
4) `previewTemplateById` - preview a template with personalisation applied

There was also some general refactoring, particularly in the unit tests.