### PR TITLE
Add to `package.json` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 ```shell
-npm install notifications-node-client
+npm install --save notifications-node-client
 ```
 
 ## Getting started


### PR DESCRIPTION
For people who don’t know much Node, this missing flag is just another thing that can trip them up.

For people who do have a lot of Node experience, they can choose to remove the `--save` flag if (for whatever reason) they don’t really want it.