### PR TITLE
Fix errant semicolon in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Otherwise the client will return an error `err`:
 
 ```javascript
 notifyClient
-	.sendEmail(templateId, emailAddress, personalisation, reference);
+	.sendEmail(templateId, emailAddress, personalisation, reference)
     .then(response => console.log(response))
     .catch(err => console.error(err))
 ;


### PR DESCRIPTION
It causes a syntax error when you copy-paste this code into your app.