### PR TITLE
Add logging of responses to example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ the _API integration_ page.
 ```javascript
 notifyClient
 	.sendSms(templateId, phoneNumber, personalisation, reference)
-	.then((response) => { })
-	.catch((err) => {})
+	.then(response => console.log(response))
+	.catch(err => console.error(err))
 ;
 ```
 
@@ -124,8 +124,8 @@ Otherwise the client will return an error `err`:
 ```javascript
 notifyClient
 	.sendEmail(templateId, emailAddress, personalisation, reference);
-    .then((response) => { })
-    .catch((err) => {})
+    .then(response => console.log(response))
+    .catch(err => console.error(err))
 ;
 ```
 


### PR DESCRIPTION
If you copy and paste the example code then our examples of what to do with responses is very unhelpful, especially if you don’t know a lot of JS. Specifically it means any error messages returned from the API get squashed and never show up in the console, so it’s hard to understand what, if anything, has gone wrong.