### PR TITLE
Minor version bump to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds option to pass in a proxy for the client to use.

See https://github.com/alphagov/notifications-node-client/pull/28