### PR TITLE
Add optional email_reply_to_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.3.0] - 2017-10-13
+
+### Changed
+
+* Updated `sendEmail` method with optional argument:
+    * `emailReplyToId` - specify the identifier of the email reply-to address (optional)
+
 ## [3.2.0] - 2017-09-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -281,6 +281,26 @@ Optional. Specifies the identifier of the email reply-to address to set for the 
 
 If you omit this argument your default email reply-to address will be set for the notification.
 
+If other optional arguments before `emailReplyToId` are not in use they need to be set to `null`.
+
+Example usage with optional reference -
+
+```
+sendEmail('123', 'test@gov.uk', null, 'your ref', '465')
+```
+
+Example usage with optional personalisation -
+
+```
+sendEmail('123', 'test@gov.uk', '{"name": "test"}', null, '465')
+```
+
+Example usage with only optional `emailReplyToId` set -
+
+```
+sendEmail('123', 'test@gov.uk', null, null, '465')
+```
+
 #### `personalisation`
 
 If a template has placeholders, you need to provide their values, for example:

--- a/README.md
+++ b/README.md
@@ -124,11 +124,45 @@ Otherwise the client will return an error `err`:
 </table>
 </details>
 
+<details>
+<summary>
+Arguments
+</summary>
+
+#### `phoneNumber`
+
+The phone number of the recipient, only required for sms notifications.
+
+#### `templateId`
+
+Find by clicking **API info** for the template you want to send.
+
+#### `reference`
+
+An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
+
+You can omit this argument if you do not require a reference for the notification.
+
+
+#### `personalisation`
+
+If a template has placeholders, you need to provide their values, for example:
+
+```javascript
+personalisation={
+    'first_name': 'Amala',
+    'reference_number': '300241',
+}
+```
+
+Otherwise the parameter can be omitted or `undefined` can be passed in its place.
+</details>
+
 ### Email
 
 ```javascript
 notifyClient
-	.sendEmail(templateId, emailAddress, personalisation, reference)
+	.sendEmail(templateId, emailAddress, personalisation, reference, emailReplyToId)
     .then(response => console.log(response))
     .catch(err => console.error(err))
 ;
@@ -225,30 +259,42 @@ Otherwise the client will return an error `err`:
 </table>
 </details>
 
+<details>
+<summary>Arguments</summary>
 
-### Arguments
-
+#### `emailAddress`
+The email address of the recipient, only required for email notifications.
 
 #### `templateId`
 
 Find by clicking **API info** for the template you want to send.
 
+#### `reference`
+
+An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
+
+You can omit this argument if you do not require a reference for the notification.
+
+#### `emailReplyToId`
+
+Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'. 
+
+If you omit this argument your default email reply-to address will be set for the notification.
+
 #### `personalisation`
 
-If a template has placeholders you need to provide their values. For example:
+If a template has placeholders, you need to provide their values, for example:
 
 ```javascript
 personalisation={
     'first_name': 'Amala',
-    'reference_number': '300241',
+    'application_number': '300241',
 }
 ```
 
 Otherwise the parameter can be omitted or `undefined` can be passed in its place.
 
-#### `reference`
-
-An optional identifier you generate if you don’t want to use Notify’s `id`. It can be used to identify a single  notification or a batch of notifications.
+</details>
 
 ## Get the status of one message
 ```javascript
@@ -420,7 +466,8 @@ Otherwise the client will return an error `err`:
 </table>
 </details>
 
-### Arguments
+<details>
+<summary>Arguments</summary>
 
 #### `templateType`
 
@@ -450,6 +497,7 @@ This is the `reference` you gave at the time of sending the notification. This c
 #### `olderThan`
 
 If omitted all messages are returned. Otherwise you can filter to retrieve all notifications older than the given notification `id`.
+</details>
 
 ## Get a template by ID
 
@@ -507,12 +555,13 @@ Otherwise the client will return an error `err`:
 </table>
 </details>
 
-### Arguments
-
+<details>
+<summary>Arguments</summary>
 
 #### `templateId`
 
 Find by clicking **API info** for the template you want to send.
+</details>
 
 ## Get a template by ID and version
 
@@ -570,7 +619,8 @@ Otherwise the client will return an error `err`:
 </table>
 </details>
 
-### Arguments
+<details>
+<summary>Arguments</summary>
 
 #### `templateId`
 
@@ -579,6 +629,7 @@ Find by clicking **API info** for the template you want to send.
 #### `version`
 
 The version number of the template
+</details>
 
 ## Get all templates
 
@@ -628,7 +679,8 @@ If no templates exist for a template type or there no templates for a service, t
 
 </details>
 
-### Arguments
+<details>
+<summary>Arguments</summary>
 
 #### `templateType`
 
@@ -637,7 +689,7 @@ If omitted all messages are returned. Otherwise you can filter by:
 * `email`
 * `sms`
 * `letter`
-
+</details>
 
 ## Generate a preview template
 
@@ -649,7 +701,6 @@ notifyClient
     .catch((err) => {})
 ;
 ```
-
 <details>
 <summary>
 Response
@@ -706,8 +757,8 @@ Otherwise the client will return an error `err`:
 </table>
 </details>
 
-### Arguments
-
+<details>
+<summary>Arguments</summary>
 
 #### `templateId`
 
@@ -725,6 +776,7 @@ personalisation={
 ```
 
 Otherwise the parameter can be omitted or `undefined` can be passed in its place.
+</details>
 
 ## Tests
 

--- a/client/notification.js
+++ b/client/notification.js
@@ -117,6 +117,7 @@ _.extend(NotifyClient.prototype, {
    * @param {String} emailAddress
    * @param {Object} personalisation
    * @param {String} reference
+   * @param {String} emailReplyToId
    *
    * @returns {Promise}
    */

--- a/client/notification.js
+++ b/client/notification.js
@@ -26,7 +26,7 @@ function NotifyClient() {
  *
  * @returns {Object}
  */
-function createNotificationPayload(type, templateId, to, personalisation, reference) {
+function createNotificationPayload(type, templateId, to, personalisation, reference, emailReplyToId) {
 
   var payload = {
     template_id: templateId
@@ -45,6 +45,10 @@ function createNotificationPayload(type, templateId, to, personalisation, refere
 
   if (reference) {
     payload.reference = reference;
+  }
+
+  if (emailReplyToId) {
+    payload.email_reply_to_id = emailReplyToId;
   }
 
   return payload;
@@ -116,9 +120,9 @@ _.extend(NotifyClient.prototype, {
    *
    * @returns {Promise}
    */
-  sendEmail: function (templateId, emailAddress, personalisation, reference) {
+  sendEmail: function (templateId, emailAddress, personalisation, reference, emailReplyToId) {
     return this.apiClient.post('/v2/notifications/email',
-      createNotificationPayload('email', templateId, emailAddress, personalisation, reference));
+      createNotificationPayload('email', templateId, emailAddress, personalisation, reference, emailReplyToId));
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/script/generate_docker_env.sh
+++ b/script/generate_docker_env.sh
@@ -17,6 +17,7 @@ env_vars=(
     FUNCTIONAL_TEST_NUMBER
     EMAIL_TEMPLATE_ID
     SMS_TEMPLATE_ID
+    EMAIL_REPLY_TO_ID
 )
 
 for env_var in "${env_vars[@]}"; do

--- a/spec/integration/schemas/v2/POST_notification_email_response.json
+++ b/spec/integration/schemas/v2/POST_notification_email_response.json
@@ -11,10 +11,6 @@
       "scheduled_for": {"oneOf":[
         {"$ref": "definitions.json#/datetime"},
         {"type": "null"}
-      ]},
-      "email_reply_to_id": {"oneOf":[
-        {"$ref": "definitions.json#/uuid"},
-        {"type": "null"}
       ]}
   },
   "additionalProperties": false,

--- a/spec/integration/schemas/v2/POST_notification_email_response.json
+++ b/spec/integration/schemas/v2/POST_notification_email_response.json
@@ -11,6 +11,10 @@
       "scheduled_for": {"oneOf":[
         {"$ref": "definitions.json#/datetime"},
         {"type": "null"}
+      ]},
+      "email_reply_to_id": {"oneOf":[
+        {"$ref": "definitions.json#/uuid"},
+        {"type": "null"}
       ]}
   },
   "additionalProperties": false,

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -22,6 +22,7 @@ describer('notification api with a live service', () => {
   const phoneNumber = process.env.FUNCTIONAL_TEST_NUMBER;
   const smsTemplateId = process.env.SMS_TEMPLATE_ID;
   const emailTemplateId = process.env.EMAIL_TEMPLATE_ID;
+  const emailReplyToId = process.env.EMAIL_REPLY_TO_ID;
 
   beforeEach(() => {
 
@@ -39,6 +40,18 @@ describer('notification api with a live service', () => {
     it('send email notification', () => {
       var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json');
       return notifyClient.sendEmail(emailTemplateId, email, personalisation, clientRef).then((response) => {
+        response.statusCode.should.equal(201);
+        expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
+        response.body.content.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
+        response.body.content.subject.should.equal('Functional Tests are good');
+        response.body.reference.should.equal(clientRef);
+        emailNotificationId = response.body.id;
+      })
+    });
+
+    it('send email notification with email_reply_to_id', () => {
+      var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json');
+      return notifyClient.sendEmail(emailTemplateId, email, personalisation, clientRef, emailReplyToId).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
@@ -132,10 +145,11 @@ describer('notification api with a live service', () => {
       });
     });
 
-    it('get all templates', () => {
+    it('get all templates', (done) => {
       return notifyClient.getAllTemplates().then((response) => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplatesJson);
+        done();
       });
     });
 

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -51,6 +51,7 @@ describer('notification api with a live service', () => {
 
     it('send email notification with email_reply_to_id', () => {
       var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json');
+      should.exist(emailReplyToId);
       return notifyClient.sendEmail(emailTemplateId, email, personalisation, clientRef, emailReplyToId).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -49,6 +49,32 @@ describe('notification api', function() {
 
     });
 
+    it('should send an email with email_reply_to_id', function(done) {
+      
+        var email = 'dom@example.com',
+          templateId = '123',
+          personalisation = {foo: 'bar'},
+          reference = '',
+          emailReplyToId = '456',          
+          data = {
+              template_id: templateId,
+              email_address: email,
+              personalisation: personalisation,
+              email_reply_to_id: emailReplyToId
+          };
+
+        notifyAuthNock
+          .post('/v2/notifications/email', data)
+          .reply(200, {"hooray": "bkbbk"});
+
+        notifyClient.sendEmail(templateId, email, personalisation, reference, emailReplyToId)
+          .then(function (response) {
+            expect(response.statusCode).to.equal(200);
+            done();
+        });
+
+    });
+
     it('should send an sms', function(done) {
 
         var phoneNo = '07525755555',


### PR DESCRIPTION
In order to support multiple email reply to's, the node client needs to be updated to provide the argument for the Notify API

- added support for email_reply_to_id
- refactored README.md in line with [python client docs](https://github.com/alphagov/notifications-python-client/blob/master/README.md)

Reference - https://www.pivotaltracker.com/story/show/150440099