### PR TITLE
Allow sendSms to accept an smsSenderId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.5.0] - 2017-11-01
+
+### Changed
+
+* Updated `sendSms` method with optional argument:
+    * `smsSenderId` - specify the identifier of the sms sender (optional)
+
 ## [3.4.0] - 2017-10-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ notifyClient.setProxy(proxyUrl);
 
 ```javascript
 notifyClient
-	.sendSms(templateId, phoneNumber, personalisation, reference)
+	.sendSms(templateId, phoneNumber, personalisation, reference, smsSenderId)
 	.then(response => console.log(response))
 	.catch(err => console.error(err))
 ;
@@ -155,7 +155,34 @@ personalisation={
 }
 ```
 
-Otherwise the parameter can be omitted or `undefined` can be passed in its place.
+If you are not using the `smsSenderId` argument, this parameter can be omitted. Otherwise `undefined` should be passed in its place.
+
+#### `smsSenderId`
+
+Optional. Specifies the identifier of the sms sender to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Text message sender'.
+
+If you omit this argument your default sms sender will be set for the notification.
+
+If other optional arguments before `smsSenderId` are not in use they need to be set to `undefined`.
+
+Example usage with optional reference -
+
+```
+sendSms('123', '+447900900123', undefined, 'your ref', '465')
+```
+
+Example usage with optional personalisation -
+
+```
+sendSms('123', '+447900900123', '{"name": "test"}', undefined, '465')
+```
+
+Example usage with only optional `smsSenderId` set -
+
+```
+sendSms('123', '+447900900123', undefined, undefined, '465')
+```
+
 </details>
 
 ### Email

--- a/README.md
+++ b/README.md
@@ -286,6 +286,63 @@ Otherwise the client will return an error `err`:
 </table>
 </details>
 
+<details>
+<summary>Arguments</summary>
+
+#### `emailAddress`
+The email address of the recipient, only required for email notifications.
+
+#### `templateId`
+
+Find by clicking **API info** for the template you want to send.
+
+#### `reference`
+
+An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
+
+You can omit this argument if you do not require a reference for the notification.
+
+#### `emailReplyToId`
+
+Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'. 
+
+If you omit this argument your default email reply-to address will be set for the notification.
+
+If other optional arguments before `emailReplyToId` are not in use they need to be set to `undefined`.
+
+Example usage with optional reference -
+
+```
+sendEmail('123', 'test@gov.uk', undefined, 'your ref', '465')
+```
+
+Example usage with optional personalisation -
+
+```
+sendEmail('123', 'test@gov.uk', '{"name": "test"}', undefined, '465')
+```
+
+Example usage with only optional `emailReplyToId` set -
+
+```
+sendEmail('123', 'test@gov.uk', undefined, undefined, '465')
+```
+
+#### `personalisation`
+
+If a template has placeholders, you need to provide their values, for example:
+
+```javascript
+personalisation={
+    'first_name': 'Amala',
+    'application_number': '300241',
+}
+```
+
+Otherwise the parameter can be omitted or `undefined` can be passed in its place.
+
+</details>
+
 ### Letter
 
 ```javascript
@@ -447,60 +504,6 @@ personalisation={
     'application_date': '2017-01-01', 		# field from template
 }
 ```
-
-</details>
-
-#### `emailAddress`
-The email address of the recipient, only required for email notifications.
-
-#### `templateId`
-
-Find by clicking **API info** for the template you want to send.
-
-#### `reference`
-
-An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
-
-You can omit this argument if you do not require a reference for the notification.
-
-#### `emailReplyToId`
-
-Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'. 
-
-If you omit this argument your default email reply-to address will be set for the notification.
-
-If other optional arguments before `emailReplyToId` are not in use they need to be set to `undefined`.
-
-Example usage with optional reference -
-
-```
-sendEmail('123', 'test@gov.uk', undefined, 'your ref', '465')
-```
-
-Example usage with optional personalisation -
-
-```
-sendEmail('123', 'test@gov.uk', '{"name": "test"}', undefined, '465')
-```
-
-Example usage with only optional `emailReplyToId` set -
-
-```
-sendEmail('123', 'test@gov.uk', undefined, undefined, '465')
-```
-
-#### `personalisation`
-
-If a template has placeholders, you need to provide their values, for example:
-
-```javascript
-personalisation={
-    'first_name': 'Amala',
-    'application_number': '300241',
-}
-```
-
-Otherwise the parameter can be omitted or `undefined` can be passed in its place.
 
 </details>
 

--- a/client/notification.js
+++ b/client/notification.js
@@ -23,10 +23,11 @@ function NotifyClient() {
  * @param {String} to
  * @param {Object} personalisation
  * @param {String} reference
+ * @param {String} replyToId
  *
  * @returns {Object}
  */
-function createNotificationPayload(type, templateId, to, personalisation, reference, emailReplyToId) {
+function createNotificationPayload(type, templateId, to, personalisation, reference, replyToId) {
 
   var payload = {
     template_id: templateId
@@ -49,8 +50,10 @@ function createNotificationPayload(type, templateId, to, personalisation, refere
     payload.reference = reference;
   }
 
-  if (emailReplyToId) {
-    payload.email_reply_to_id = emailReplyToId;
+  if (replyToId && type == 'email') {
+    payload.email_reply_to_id = replyToId;
+  } else if (replyToId && type == 'sms') {
+    payload.sms_sender_id = replyToId;
   }
 
   return payload;
@@ -130,12 +133,13 @@ _.extend(NotifyClient.prototype, {
    * @param {String} phoneNumber
    * @param {Object} personalisation
    * @param {String} reference
+   * @param {String} smsSenderId
    *
    * @returns {Promise}
    */
-  sendSms: function (templateId, phoneNumber, personalisation, reference) {
+  sendSms: function (templateId, phoneNumber, personalisation, reference, smsSenderId) {
     return this.apiClient.post('/v2/notifications/sms',
-      createNotificationPayload('sms', templateId, phoneNumber, personalisation, reference));
+      createNotificationPayload('sms', templateId, phoneNumber, personalisation, reference, smsSenderId));
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/script/generate_docker_env.sh
+++ b/script/generate_docker_env.sh
@@ -19,6 +19,7 @@ env_vars=(
     LETTER_TEMPLATE_ID
     SMS_TEMPLATE_ID
     EMAIL_REPLY_TO_ID
+    SMS_SENDER_ID
 )
 
 for env_var in "${env_vars[@]}"; do

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -37,6 +37,7 @@ describer('notification api with a live service', () => {
     postcode: 'Bar',
   };
   const smsTemplateId = process.env.SMS_TEMPLATE_ID;
+  const smsSenderId = process.env.SMS_SENDER_ID;
   const emailTemplateId = process.env.EMAIL_TEMPLATE_ID;
   const emailReplyToId = process.env.EMAIL_REPLY_TO_ID;
   const letterTemplateId = process.env.LETTER_TEMPLATE_ID;
@@ -82,6 +83,17 @@ describer('notification api with a live service', () => {
     it('send sms notification', () => {
       var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json');
       return notifyClient.sendSms(smsTemplateId, phoneNumber, personalisation).then((response) => {
+        response.statusCode.should.equal(201);
+        expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
+        response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
+        smsNotificationId = response.body.id;
+      });
+    });
+
+    it('send sms notification with sms_sender_id', () => {
+      var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json');
+      should.exist(smsSenderId);
+      return notifyClient.sendSms(smsTemplateId, phoneNumber, personalisation, clientRef, smsSenderId).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -37,9 +37,9 @@ describer('notification api with a live service', () => {
     postcode: 'Bar',
   };
   const smsTemplateId = process.env.SMS_TEMPLATE_ID;
-  const smsSenderId = process.env.SMS_SENDER_ID;
+  const smsSenderId = process.env.SMS_SENDER_ID || undefined;
   const emailTemplateId = process.env.EMAIL_TEMPLATE_ID;
-  const emailReplyToId = process.env.EMAIL_REPLY_TO_ID;
+  const emailReplyToId = process.env.EMAIL_REPLY_TO_ID || undefined;
   const letterTemplateId = process.env.LETTER_TEMPLATE_ID;
 
   beforeEach(() => {

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -97,6 +97,31 @@ describe('notification api', function() {
           });
     });
 
+    it('should send an sms with smsSenderId', function(done) {
+
+        var phoneNo = '07525755555',
+          templateId = '123',
+          personalisation = {foo: 'bar'},
+          reference = '',
+          sms_sender_id = '456',
+          data = {
+              template_id: templateId,
+              phone_number: phoneNo,
+              personalisation: personalisation,
+              sms_sender_id: sms_sender_id
+          };
+
+        notifyAuthNock
+          .post('/v2/notifications/sms', data)
+          .reply(200, {"hooray": "bkbbk"});
+
+        notifyClient.sendSms(templateId, phoneNo, personalisation, reference, sms_sender_id)
+          .then(function (response) {
+              expect(response.statusCode).to.equal(200);
+              done();
+          });
+    });
+
     it('should send a letter', function(done) {
       
         var templateId = '123',


### PR DESCRIPTION
When using the `sendSms` function, you can now choose to specify which
sender you want the notification to come from by passing in an
`smsSenderId`. If this is not included, the SMS notification will come
from the default sender.

[Pivotal story](https://www.pivotaltracker.com/story/show/152106587)
