### PR TITLE
Fix randomly failing unit tests by mocking date

### DIFF
--- a/spec/api_client.js
+++ b/spec/api_client.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect,
+  MockDate = require('mockdate'),
   ApiClient = require('../client/api_client.js'),
   nock = require('nock'),
   createGovukNotifyToken = require('../client/authentication.js'),
@@ -6,6 +7,14 @@ var expect = require('chai').expect,
 
 
 describe('api client', function () {
+
+  beforeEach(function() {
+    MockDate.set(1234567890000);
+  });
+
+  afterEach(function() {
+    MockDate.reset();
+  });
 
   it('should make a get request with correct headers', function (done) {
 

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -1,6 +1,9 @@
 var expect = require('chai').expect, NotifyClient = require('../client/notification.js').NotifyClient,
+    MockDate = require('mockdate'),
     nock = require('nock'),
     createGovukNotifyToken = require('../client/authentication.js');
+
+MockDate.set(1234567890000);
 
 const baseUrl = 'http://localhost';
 const serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1';
@@ -22,6 +25,14 @@ function getNotifyAuthNock() {
 }
 
 describe('notification api', function() {
+
+    beforeEach(function() {
+      MockDate.set(1234567890000);
+    });
+
+    afterEach(function() {
+      MockDate.reset();
+    });
 
     var notifyClient = getNotifyClient();
     var notifyAuthNock = getNotifyAuthNock();
@@ -357,3 +368,5 @@ describe('notification api', function() {
     });
 
 });
+
+MockDate.reset();


### PR DESCRIPTION
The date was not being mocked in the `api_client.js` and `notification.js`
unit tests, which was causing these to randomly fail. This is because
the date gets used to generate a Notify token for the request header. By
using the real date, the request that we mocked using Nock and the request
that we attempted to make would occasionally have different headers.