### PR TITLE
Change arguments for sendSms, sendEmail and sendLetter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.0] - 2017-11-07
+
+### Changed
+
+* Updated `sendSms`, `sendEmail` and `sendLetter` to take an `options` object as a parameter.
+    * `personalisation`, `reference`, `smsSenderId` and `emailReplyToId` now need to be passed to these functions inside `options`.
+
 ## [3.5.0] - 2017-11-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ sendSms('123', '+447900900123', undefined, undefined, '465')
 
 ```javascript
 notifyClient
-	.sendEmail(templateId, emailAddress, personalisation, reference, emailReplyToId)
+    .sendEmail(templateId, emailAddress, options)
     .then(response => console.log(response))
     .catch(err => console.error(err))
 ;
@@ -289,57 +289,42 @@ Otherwise the client will return an error `err`:
 <details>
 <summary>Arguments</summary>
 
-#### `emailAddress`
-The email address of the recipient, only required for email notifications.
-
 #### `templateId`
 
 Find by clicking **API info** for the template you want to send.
 
-#### `reference`
+#### `emailAddress`
+
+The email address of the recipient, only required for email notifications.
+
+#### `options`
+
+An object which can contain `personalisation`, `reference` and `emailReplyToId`. If none of these are needed, `options` can be omitted.
+
+##### `reference`
 
 An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
 
 You can omit this argument if you do not require a reference for the notification.
 
-#### `emailReplyToId`
+##### `emailReplyToId`
 
 Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'. 
 
 If you omit this argument your default email reply-to address will be set for the notification.
 
-If other optional arguments before `emailReplyToId` are not in use they need to be set to `undefined`.
-
-Example usage with optional reference -
-
-```
-sendEmail('123', 'test@gov.uk', undefined, 'your ref', '465')
-```
-
-Example usage with optional personalisation -
-
-```
-sendEmail('123', 'test@gov.uk', '{"name": "test"}', undefined, '465')
-```
-
-Example usage with only optional `emailReplyToId` set -
-
-```
-sendEmail('123', 'test@gov.uk', undefined, undefined, '465')
-```
-
-#### `personalisation`
+##### `personalisation`
 
 If a template has placeholders, you need to provide their values, for example:
 
 ```javascript
-personalisation={
+personalisation: {
     'first_name': 'Amala',
     'application_number': '300241',
 }
 ```
 
-Otherwise the parameter can be omitted or `undefined` can be passed in its place.
+Otherwise the parameter can be omitted.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -316,16 +316,15 @@ Otherwise the parameter can be omitted.
 
 ```javascript
 notifyClient
-    .sendLetter(templateId, personalisation, reference)
+    .sendLetter(templateId, options)
     .then(response => console.log(response))
     .catch(err => console.error(err))
 ;
 ```
-
-where `personalisation` is
+where `personalisation` inside the `options` object is
 
 ```javascript
-personalisation={
+personalisation: {
     'address_line_1': 'The Occupier',  # required
     'address_line_2': '123 High Street', # required
     'address_line_3': 'London',
@@ -446,13 +445,17 @@ Otherwise the client will raise a `HTTPError`:
 
 Find by clicking **API info** for the template you want to send.
 
-#### `reference`
+#### `options`
+
+An object which contains `personalisation` and can also contain an optional `reference`.
+
+##### `reference`
 
 An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
 
 You can omit this argument if you do not require a reference for the notification.
 
-#### `personalisation`
+##### `personalisation`
 
 The letter must contain:
 
@@ -461,7 +464,7 @@ The letter must contain:
 - fields from template
 
 ```javascript
-personalisation={
+personalisation: {
     'address_line_1': 'The Occupier', 		# mandatory address field
     'address_line_2': 'Flat 2', 		# mandatory address field
     'address_line_3': '123 High Street', 	# optional address field

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ notifyClient.setProxy(proxyUrl);
 
 ```javascript
 notifyClient
-	.sendSms(templateId, phoneNumber, personalisation, reference, smsSenderId)
+	.sendSms(templateId, phoneNumber, options)
 	.then(response => console.log(response))
 	.catch(err => console.error(err))
 ;
@@ -137,7 +137,11 @@ The phone number of the recipient, only required for sms notifications.
 
 Find by clicking **API info** for the template you want to send.
 
-#### `reference`
+#### `options`
+
+An object which can contain `personalisation`, `reference` and `smsSenderId`. If none of these are needed, `options` can be omitted.
+
+##### `reference`
 
 An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
 
@@ -149,39 +153,19 @@ You can omit this argument if you do not require a reference for the notificatio
 If a template has placeholders, you need to provide their values, for example:
 
 ```javascript
-personalisation={
+personalisation: {
     'first_name': 'Amala',
     'reference_number': '300241',
 }
 ```
 
-If you are not using the `smsSenderId` argument, this parameter can be omitted. Otherwise `undefined` should be passed in its place.
+If you are not using the `smsSenderId` argument, this parameter can be omitted.
 
-#### `smsSenderId`
+##### `smsSenderId`
 
 Optional. Specifies the identifier of the sms sender to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Text message sender'.
 
 If you omit this argument your default sms sender will be set for the notification.
-
-If other optional arguments before `smsSenderId` are not in use they need to be set to `undefined`.
-
-Example usage with optional reference -
-
-```
-sendSms('123', '+447900900123', undefined, 'your ref', '465')
-```
-
-Example usage with optional personalisation -
-
-```
-sendSms('123', '+447900900123', '{"name": "test"}', undefined, '465')
-```
-
-Example usage with only optional `smsSenderId` set -
-
-```
-sendSms('123', '+447900900123', undefined, undefined, '465')
-```
 
 </details>
 

--- a/client/notification.js
+++ b/client/notification.js
@@ -116,13 +116,16 @@ _.extend(NotifyClient.prototype, {
    *
    * @param {String} templateId
    * @param {String} emailAddress
-   * @param {Object} personalisation
-   * @param {String} reference
-   * @param {String} emailReplyToId
+   * @param {Object} options
    *
    * @returns {Promise}
    */
-  sendEmail: function (templateId, emailAddress, personalisation, reference, emailReplyToId) {
+  sendEmail: function (templateId, emailAddress, options) {
+    var options = options || {},
+      personalisation = options.personalisation || undefined,
+      reference = options.reference || undefined,
+      emailReplyToId = options.emailReplyToId || undefined;
+
     return this.apiClient.post('/v2/notifications/email',
       createNotificationPayload('email', templateId, emailAddress, personalisation, reference, emailReplyToId));
   },

--- a/client/notification.js
+++ b/client/notification.js
@@ -134,13 +134,16 @@ _.extend(NotifyClient.prototype, {
    *
    * @param {String} templateId
    * @param {String} phoneNumber
-   * @param {Object} personalisation
-   * @param {String} reference
-   * @param {String} smsSenderId
+   * @param {Object} options
    *
    * @returns {Promise}
    */
-  sendSms: function (templateId, phoneNumber, personalisation, reference, smsSenderId) {
+  sendSms: function (templateId, phoneNumber, options) {
+    var options = options || {};
+    var personalisation = options.personalisation || undefined;
+    var reference = options.reference || undefined;
+    var smsSenderId = options.smsSenderId || undefined;
+
     return this.apiClient.post('/v2/notifications/sms',
       createNotificationPayload('sms', templateId, phoneNumber, personalisation, reference, smsSenderId));
   },

--- a/client/notification.js
+++ b/client/notification.js
@@ -151,12 +151,15 @@ _.extend(NotifyClient.prototype, {
   /**
    *
    * @param {String} templateId
-   * @param {Object} personalisation
-   * @param {String} reference
+   * @param {Object} options
    *
    * @returns {Promise}
    */
-  sendLetter: function (templateId, personalisation, reference) {
+  sendLetter: function (templateId, options) {
+    var options = options || {};
+    var personalisation = options.personalisation || undefined;
+    var reference = options.reference || undefined;
+
     return this.apiClient.post('/v2/notifications/letter',
       createNotificationPayload('letter', templateId, undefined, personalisation, reference));
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -110,8 +110,10 @@ describer('notification api with a live service', () => {
     });
 
     it('send letter notification', () => {
-      var postLetterNotificationResponseJson = require('./schemas/v2/POST_notification_letter_response.json');
-      return notifyClient.sendLetter(letterTemplateId, letterContact).then((response) => {
+      var postLetterNotificationResponseJson = require('./schemas/v2/POST_notification_letter_response.json'),
+        options = {personalisation: letterContact};
+
+      return notifyClient.sendLetter(letterTemplateId, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postLetterNotificationResponseJson);
         response.body.content.body.should.equal('Hello ' + letterContact.address_line_1);

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -85,8 +85,10 @@ describer('notification api with a live service', () => {
     });
 
     it('send sms notification', () => {
-      var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json');
-      return notifyClient.sendSms(smsTemplateId, phoneNumber, personalisation).then((response) => {
+      var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json'),
+        options = {personalisation: personalisation};
+
+      return notifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
@@ -95,9 +97,11 @@ describer('notification api with a live service', () => {
     });
 
     it('send sms notification with sms_sender_id', () => {
-      var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json');
+      var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json'),
+        options = {personalisation: personalisation, reference: clientRef, smsSenderId: smsSenderId};
+
       should.exist(smsSenderId);
-      return notifyClient.sendSms(smsTemplateId, phoneNumber, personalisation, clientRef, smsSenderId).then((response) => {
+      return notifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -56,8 +56,10 @@ describer('notification api with a live service', () => {
   describe('notifications', () => {
 
     it('send email notification', () => {
-      var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json');
-      return notifyClient.sendEmail(emailTemplateId, email, personalisation, clientRef).then((response) => {
+      var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json'),
+        options = {personalisation: personalisation, reference: clientRef};
+
+      return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
@@ -68,9 +70,11 @@ describer('notification api with a live service', () => {
     });
 
     it('send email notification with email_reply_to_id', () => {
-      var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json');
+      var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json'),
+        options = {personalisation: personalisation, reference: clientRef, emailReplyToId: emailReplyToId};
+
       should.exist(emailReplyToId);
-      return notifyClient.sendEmail(emailTemplateId, email, personalisation, clientRef, emailReplyToId).then((response) => {
+      return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -82,18 +82,20 @@ describe('notification api', function() {
 
         var phoneNo = '07525755555',
           templateId = '123',
-          personalisation = {foo: 'bar'},
+          options = {
+            personalisation: {foo: 'bar'},
+          },
           data = {
               template_id: templateId,
               phone_number: phoneNo,
-              personalisation: personalisation
+              personalisation: options.personalisation
           };
 
         notifyAuthNock
           .post('/v2/notifications/sms', data)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient.sendSms(templateId, phoneNo, personalisation)
+        notifyClient.sendSms(templateId, phoneNo, options)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
               done();
@@ -104,21 +106,22 @@ describe('notification api', function() {
 
         var phoneNo = '07525755555',
           templateId = '123',
-          personalisation = {foo: 'bar'},
-          reference = '',
-          sms_sender_id = '456',
+          options = {
+            personalisation: {foo: 'bar'},
+            smsSenderId: '456',
+          },
           data = {
               template_id: templateId,
               phone_number: phoneNo,
-              personalisation: personalisation,
-              sms_sender_id: sms_sender_id
+              personalisation: options.personalisation,
+              sms_sender_id: options.smsSenderId,
           };
 
         notifyAuthNock
           .post('/v2/notifications/sms', data)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient.sendSms(templateId, phoneNo, personalisation, reference, sms_sender_id)
+        notifyClient.sendSms(templateId, phoneNo, options)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
               done();

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -30,18 +30,20 @@ describe('notification api', function() {
 
         var email = 'dom@example.com',
           templateId = '123',
-          personalisation = {foo: 'bar'},
+          options = {
+            personalisation: {foo: 'bar'},
+          },
           data = {
               template_id: templateId,
               email_address: email,
-              personalisation: personalisation
+              personalisation: options.personalisation
           };
 
         notifyAuthNock
           .post('/v2/notifications/email', data)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient.sendEmail(templateId, email, personalisation)
+        notifyClient.sendEmail(templateId, email, options)
           .then(function (response) {
             expect(response.statusCode).to.equal(200);
             done();
@@ -53,21 +55,22 @@ describe('notification api', function() {
       
         var email = 'dom@example.com',
           templateId = '123',
-          personalisation = {foo: 'bar'},
-          reference = '',
-          emailReplyToId = '456',          
+          options = {
+            personalisation: {foo: 'bar'},
+            emailReplyToId: '456',
+          },
           data = {
               template_id: templateId,
               email_address: email,
-              personalisation: personalisation,
-              email_reply_to_id: emailReplyToId
+              personalisation: options.personalisation,
+              email_reply_to_id: options.emailReplyToId
           };
 
         notifyAuthNock
           .post('/v2/notifications/email', data)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient.sendEmail(templateId, email, personalisation, reference, emailReplyToId)
+        notifyClient.sendEmail(templateId, email, options)
           .then(function (response) {
             expect(response.statusCode).to.equal(200);
             done();

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -131,21 +131,23 @@ describe('notification api', function() {
     it('should send a letter', function(done) {
       
         var templateId = '123',
-          personalisation = {
-            address_line_1: 'Mr Tester',
-            address_line_2: '1 Test street',
-            postcode: 'NW1 2UN'
+          options = {
+            personalisation: {
+              address_line_1: 'Mr Tester',
+              address_line_2: '1 Test street',
+              postcode: 'NW1 2UN'
+            },
           },
           data = {
               template_id: templateId,
-              personalisation: personalisation
+              personalisation: options.personalisation
           };
 
         notifyAuthNock
           .post('/v2/notifications/letter', data)
           .reply(200, {"hooray": "bkbbk"});
 
-        notifyClient.sendLetter(templateId, personalisation)
+        notifyClient.sendLetter(templateId, options)
           .then(function (response) {
               expect(response.statusCode).to.equal(200);
               done();


### PR DESCRIPTION
Changed `sendSms`, `sendEmail` and `sendLetter` functions to accept an `options` object as a parameter. These functions were taking an increasing number of optional arguments. Passing in an options object simplifies them and means that we don't need to pass in `undefined` when we don't want to use all the arguments.

This is a breaking change to these functions, so requires a major version bump.