### PR TITLE
Remove unused Crypto dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Updated `sendSms`, `sendEmail` and `sendLetter` to take an `options` object as a parameter.
     * `personalisation`, `reference`, `smsSenderId` and `emailReplyToId` now need to be passed to these functions inside `options`.
+* Removed the unused `Crypto` dependency
 
 ## [3.5.0] - 2017-11-01
 

--- a/client/authentication.js
+++ b/client/authentication.js
@@ -1,5 +1,4 @@
 var jwt = require('jsonwebtoken');
-var crypto = require('crypto');
 
 
 function createGovukNotifyToken(request_method, request_path, secret, client_id) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "GDS developers",
   "license": "MIT",
   "dependencies": {
-    "crypto": "0.0.3",
     "jsonwebtoken": "7.4.1",
     "request": "^2.73.0",
     "request-promise": "^4.0.1",


### PR DESCRIPTION
The Crypto dependency is deprecated, but is also is not being used, so can be removed.

This addresses issue #37.