### PR TITLE
Reject bad options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ notifyClient.setProxy(proxyUrl);
 
 ### Text message
 
-#### Method 
+#### Method
 
 <details>
 <summary>
@@ -236,6 +236,12 @@ An optional identifier you generate. The `reference` can be used as a unique ref
 
 You can omit this argument if you do not require a reference for the notification.
 
+##### `emailReplyToId`
+
+Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'.
+
+If you omit this argument your default email reply-to address will be set for the notification.
+
 ##### `personalisation`
 
 If a template has placeholders, you need to provide their values, for example:
@@ -249,7 +255,7 @@ personalisation={
 
 ##### `emailReplyToId`
 
-Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'. 
+Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'.
 If you omit this argument your default email reply-to address will be set for the notification.
 If other optional arguments before `emailReplyToId` are not in use they need to be set to `undefined`.
 
@@ -595,7 +601,7 @@ If omitted all messages are returned. Otherwise you can filter to retrieve all n
 
 ## Get a template by ID
 
-#### Method 
+#### Method
 
 <details>
 <summary>
@@ -896,7 +902,3 @@ To run the integration tests:
 ```sh
 npm test --integration
 ```
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ Click here to expand for more information.
 
 ```javascript
 notifyClient
-	.sendSms(templateId, phoneNumber, personalisation, reference, smsSenderId)
+	.sendSms(templateId, phoneNumber, {
+			personalisation: personalisation,
+			reference: reference,
+			smsSenderId: smsSenderId})
 	.then(response => console.log(response))
 	.catch(err => console.error(err))
 ;
@@ -109,7 +112,8 @@ The phone number of the recipient, only required for sms notifications.
 
 Find by clicking **API info** for the template you want to send.
 
-##### `reference`
+##### `options`
+###### `reference`
 
 An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
 
@@ -126,7 +130,7 @@ personalisation={
 }
 ```
 
-If you are not using the `smsSenderId` argument, this parameter can be omitted. Otherwise `undefined` should be passed in its place.
+This does not need to be provided if your template does not contain placeholders.
 
 ##### `smsSenderId`
 
@@ -134,25 +138,7 @@ Optional. Specifies the identifier of the sms sender to set for the notification
 
 If you omit this argument your default sms sender will be set for the notification.
 
-If other optional arguments before `smsSenderId` are not in use they need to be set to `undefined`.
-
 Example usage with optional reference -
-
-```
-sendSms('123', '+447900900123', undefined, 'your ref', '465')
-```
-
-Example usage with optional personalisation -
-
-```
-sendSms('123', '+447900900123', '{"name": "test"}', undefined, '465')
-```
-
-Example usage with only optional `smsSenderId` set -
-
-```
-sendSms('123', '+447900900123', undefined, undefined, '465')
-```
 
 </details>
 
@@ -168,7 +154,10 @@ Click here to expand for more information.
 
 ```javascript
 notifyClient
-	.sendEmail(templateId, emailAddress, personalisation, reference, emailReplyToId)
+	.sendEmail(templateId, emailAddress, {
+			personalisation: personalisation,
+			reference: reference,
+			emailReplyToId: emailReplyToId})
     .then(response => console.log(response))
     .catch(err => console.error(err))
 ;
@@ -230,19 +219,20 @@ The email address of the recipient, only required for email notifications.
 
 Find by clicking **API info** for the template you want to send.
 
-##### `reference`
+##### `options`
+###### `reference`
 
 An optional identifier you generate. The `reference` can be used as a unique reference for the notification. Because Notify does not require this reference to be unique you could also use this reference to identify a batch or group of notifications.
 
 You can omit this argument if you do not require a reference for the notification.
 
-##### `emailReplyToId`
+###### `emailReplyToId`
 
 Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'.
 
 If you omit this argument your default email reply-to address will be set for the notification.
 
-##### `personalisation`
+###### `personalisation`
 
 If a template has placeholders, you need to provide their values, for example:
 
@@ -257,20 +247,6 @@ personalisation={
 
 Optional. Specifies the identifier of the email reply-to address to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Email reply to addresses'.
 If you omit this argument your default email reply-to address will be set for the notification.
-If other optional arguments before `emailReplyToId` are not in use they need to be set to `undefined`.
-
-Example usage with optional reference -
-```
-sendEmail('123', 'test@gov.uk', undefined, 'your ref', '465')
-```
-Example usage with optional personalisation -
-```
-sendEmail('123', 'test@gov.uk', '{"name": "test"}', undefined, '465')
-```
-Example usage with only optional `emailReplyToId` set -
-```
-sendEmail('123', 'test@gov.uk', undefined, undefined, '465')
-```
 
 </details>
 
@@ -286,7 +262,9 @@ Click here to expand for more information.
 
 ```javascript
 notifyClient
-    .sendLetter(templateId, personalisation, reference)
+    .sendLetter(templateId, {
+				personalisation: personalisation,
+				reference: reference})
     .then(response => console.log(response))
     .catch(err => console.error object)
 ;
@@ -296,12 +274,12 @@ where `personalisation` is
 
 ```javascript
 personalisation={
-    'address_line_1': 'The Occupier',  # required
-    'address_line_2': '123 High Street', # required
-    'address_line_3': 'London',
-    'postcode': 'SW14 6BH',  # required
+    address_line_1: 'The Occupier',  // required
+    address_line_2: '123 High Street', // required
+    address_line_3: 'London',
+    postcode: 'SW14 6BH',  // required
 
-    ... # any other optional address lines, or personalisation fields found in your template
+    // ... any other optional address lines, or personalisation fields found in your template
 },
 ```
 </details>
@@ -374,15 +352,15 @@ The letter must contain:
 
 ```javascript
 personalisation={
-    'address_line_1': 'The Occupier', 		# mandatory address field
-    'address_line_2': 'Flat 2', 		# mandatory address field
-    'address_line_3': '123 High Street', 	# optional address field
-    'address_line_4': 'Richmond upon Thames', 	# optional address field
-    'address_line_5': 'London', 		# optional address field
-    'address_line_6': 'Middlesex', 		# optional address field
-    'postcode': 'SW14 6BH', 			# mandatory address field
-    'application_id': '1234', 			# field from template
-    'application_date': '2017-01-01', 		# field from template
+  address_line_1: 'The Occupier',  // mandatory address field
+  address_line_2: 'Flat 2',  // mandatory address field
+  address_line_3: '123 High Street',  // optional address field
+  address_line_4: 'Richmond upon Thames',  // optional address field
+  address_line_5: 'London',  // optional address field
+  address_line_6: 'Middlesex',  // optional address field
+  postcode: 'SW14 6BH',  // mandatory address field
+  application_id: '1234',  // field from template
+  application_date: '2017-01-01',  // field from template
 }
 ```
 

--- a/client/notification.js
+++ b/client/notification.js
@@ -37,12 +37,10 @@ function createNotificationPayload(type, templateId, to, personalisation, refere
     payload.email_address = to;
   } else if (type == 'sms') {
     payload.phone_number = to;
-  } 
+  }
 
-  if (type == 'letter') {
+  if (type == 'letter' || personalisation) {
     // personalisation mandatory for letters
-    payload.personalisation = personalisation;
-  } else if (!!personalisation) {
     payload.personalisation = personalisation;
   }
 
@@ -70,7 +68,7 @@ function createNotificationPayload(type, templateId, to, personalisation, refere
  */
 function buildGetAllNotificationsQuery(templateType, status, reference, olderThanId) {
 
-  payload = {}
+  let payload = {}
 
   if (templateType) {
     payload.template_type = templateType;
@@ -94,7 +92,7 @@ function buildGetAllNotificationsQuery(templateType, status, reference, olderTha
 function buildQueryStringFromDict(dictionary) {
   var queryString = Object.keys(dictionary).map(function(key) {
     return [key, dictionary[key]].map(encodeURIComponent).join("=");
-  }).join("&");
+  }).join('&');
 
   return queryString ? '?' + queryString : '';
 }
@@ -121,8 +119,9 @@ _.extend(NotifyClient.prototype, {
    * @returns {Promise}
    */
   sendEmail: function (templateId, emailAddress, options) {
-    var options = options || {},
-      personalisation = options.personalisation || undefined,
+    options = options || {};
+    
+    var personalisation = options.personalisation || undefined,
       reference = options.reference || undefined,
       emailReplyToId = options.emailReplyToId || undefined;
 
@@ -139,7 +138,9 @@ _.extend(NotifyClient.prototype, {
    * @returns {Promise}
    */
   sendSms: function (templateId, phoneNumber, options) {
-    var options = options || {};
+    options = options || {};
+    
+
     var personalisation = options.personalisation || undefined;
     var reference = options.reference || undefined;
     var smsSenderId = options.smsSenderId || undefined;
@@ -156,7 +157,8 @@ _.extend(NotifyClient.prototype, {
    * @returns {Promise}
    */
   sendLetter: function (templateId, options) {
-    var options = options || {};
+    options = options || {};
+    
     var personalisation = options.personalisation || undefined;
     var reference = options.reference || undefined;
 
@@ -216,7 +218,7 @@ _.extend(NotifyClient.prototype, {
    * @returns {Promise}
    */
   getAllTemplates: function(templateType) {
-    templateQuery = ''
+    let templateQuery = ''
 
     if (templateType) {
       templateQuery = '?type=' + templateType;
@@ -234,9 +236,9 @@ _.extend(NotifyClient.prototype, {
    */
   previewTemplateById: function(templateId, personalisation) {
 
-    payload = {}
+    let payload = {}
 
-    if (!!personalisation) {
+    if (personalisation) {
       payload.personalisation = personalisation;
     }
 

--- a/client/notification.js
+++ b/client/notification.js
@@ -98,12 +98,16 @@ function buildQueryStringFromDict(dictionary) {
 }
 
 function checkOptionsKeys(allowedKeys, options) {
-  var invalidKeys = Object.keys(options).filter((key_name) =>
+  let invalidKeys = Object.keys(options).filter((key_name) =>
     !allowedKeys.includes(key_name)
   );
 
   if (invalidKeys.length) {
-    return new Error('Options ' + JSON.stringify(invalidKeys) + ' not recognised');
+    let err_msg = (
+      'NotifyClient now uses an options configuration object. Options ' + JSON.stringify(invalidKeys) +
+      ' not recognised. Please refer to the README.md for more information'
+    )
+    return new Error(err_msg);
   }
   return null;
 }

--- a/client/notification.js
+++ b/client/notification.js
@@ -105,7 +105,7 @@ function checkOptionsKeys(allowedKeys, options) {
   if (invalidKeys.length) {
     let err_msg = (
       'NotifyClient now uses an options configuration object. Options ' + JSON.stringify(invalidKeys) +
-      ' not recognised. Please refer to the README.md for more information'
+      ' not recognised. Please refer to the README.md for more information on method signatures.'
     )
     return new Error(err_msg);
   }

--- a/client/notification.js
+++ b/client/notification.js
@@ -97,6 +97,17 @@ function buildQueryStringFromDict(dictionary) {
   return queryString ? '?' + queryString : '';
 }
 
+function checkOptionsKeys(allowedKeys, options) {
+  var invalidKeys = Object.keys(options).filter((key_name) =>
+    !allowedKeys.includes(key_name)
+  );
+
+  if (invalidKeys.length) {
+    return new Error('Options ' + JSON.stringify(invalidKeys) + ' not recognised');
+  }
+  return null;
+}
+
 _.extend(NotifyClient.prototype, {
   /**
    * Usage:
@@ -120,7 +131,10 @@ _.extend(NotifyClient.prototype, {
    */
   sendEmail: function (templateId, emailAddress, options) {
     options = options || {};
-    
+    var err = checkOptionsKeys(['personalisation', 'reference', 'emailReplyToId'], options)
+    if (err) {
+      return Promise.reject(err);
+    }
     var personalisation = options.personalisation || undefined,
       reference = options.reference || undefined,
       emailReplyToId = options.emailReplyToId || undefined;
@@ -139,7 +153,10 @@ _.extend(NotifyClient.prototype, {
    */
   sendSms: function (templateId, phoneNumber, options) {
     options = options || {};
-    
+    var err = checkOptionsKeys(['personalisation', 'reference', 'smsSenderId'], options)
+    if (err) {
+      return Promise.reject(err);
+    }
 
     var personalisation = options.personalisation || undefined;
     var reference = options.reference || undefined;
@@ -158,7 +175,10 @@ _.extend(NotifyClient.prototype, {
    */
   sendLetter: function (templateId, options) {
     options = options || {};
-    
+    var err = checkOptionsKeys(['personalisation', 'reference'], options)
+    if (err) {
+      return Promise.reject(err);
+    }
     var personalisation = options.personalisation || undefined;
     var reference = options.reference || undefined;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -25,13 +25,13 @@ function getNotifyAuthNock() {
   return notifyNock;
 }
 
-describe('notification api', function() {
+describe('notification api', () => {
 
-  beforeEach(function() {
+  beforeEach(() => {
     MockDate.set(1234567890000);
   });
 
-  afterEach(function() {
+  afterEach(() => {
     MockDate.reset();
   });
 
@@ -39,7 +39,7 @@ describe('notification api', function() {
   let notifyAuthNock = getNotifyAuthNock();
 
   describe('sendEmail', () => {
-    it('should send an email', function(done) {
+    it('should send an email', () => {
 
       let email = 'dom@example.com',
         templateId = '123',
@@ -56,15 +56,14 @@ describe('notification api', function() {
       .post('/v2/notifications/email', data)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.sendEmail(templateId, email, options)
+      return notifyClient.sendEmail(templateId, email, options)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
 
     });
 
-    it('should send an email with email_reply_to_id', function() {
+    it('should send an email with email_reply_to_id', () => {
 
       let email = 'dom@example.com',
         templateId = '123',
@@ -106,7 +105,7 @@ describe('notification api', function() {
 
   describe('sendSms', () => {
 
-    it('should send an sms', function(done) {
+    it('should send an sms', () => {
 
       let phoneNo = '07525755555',
         templateId = '123',
@@ -123,14 +122,13 @@ describe('notification api', function() {
       .post('/v2/notifications/sms', data)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.sendSms(templateId, phoneNo, options)
+      return notifyClient.sendSms(templateId, phoneNo, options)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
-    it('should send an sms with smsSenderId', function(done) {
+    it('should send an sms with smsSenderId', () => {
 
       let phoneNo = '07525755555',
         templateId = '123',
@@ -149,10 +147,9 @@ describe('notification api', function() {
       .post('/v2/notifications/sms', data)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.sendSms(templateId, phoneNo, options)
+      return notifyClient.sendSms(templateId, phoneNo, options)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
@@ -172,7 +169,7 @@ describe('notification api', function() {
 
   describe('sendLetter', () => {
 
-    it('should send a letter', function(done) {
+    it('should send a letter', () => {
 
       let templateId = '123',
         options = {
@@ -191,10 +188,9 @@ describe('notification api', function() {
       .post('/v2/notifications/letter', data)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.sendLetter(templateId, options)
+      return notifyClient.sendLetter(templateId, options)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
@@ -213,7 +209,7 @@ describe('notification api', function() {
 
   });
 
-  it('should get notification by id', function(done) {
+  it('should get notification by id', () => {
 
     let notificationId = 'wfdfdgf';
 
@@ -221,29 +217,27 @@ describe('notification api', function() {
       .get('/v2/notifications/' + notificationId)
       .reply(200, {hooray: 'bkbbk'});
 
-    notifyClient.getNotificationById(notificationId)
+    return notifyClient.getNotificationById(notificationId)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
   });
 
   describe('getNotifications', () => {
 
-    it('should get all notifications', function(done) {
+    it('should get all notifications', () => {
 
       notifyAuthNock
       .get('/v2/notifications')
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.getNotifications()
+      return notifyClient.getNotifications()
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
-    it('should get all notifications with a reference', function(done) {
+    it('should get all notifications with a reference', () => {
 
       let reference = 'myref';
 
@@ -251,14 +245,13 @@ describe('notification api', function() {
       .get('/v2/notifications?reference=' + reference)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.getNotifications(undefined, undefined, reference)
+      return notifyClient.getNotifications(undefined, undefined, reference)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
-    it('should get all failed notifications', function(done) {
+    it('should get all failed notifications', () => {
 
       let status = 'failed';
 
@@ -266,14 +259,13 @@ describe('notification api', function() {
       .get('/v2/notifications?status=' + status)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.getNotifications(undefined, 'failed')
+      return notifyClient.getNotifications(undefined, 'failed')
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
-    it('should get all failed sms notifications', function(done) {
+    it('should get all failed sms notifications', () => {
 
       let templateType = 'sms';
       let status = 'failed';
@@ -282,14 +274,13 @@ describe('notification api', function() {
       .get('/v2/notifications?template_type=' + templateType + '&status=' + status)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.getNotifications(templateType, status)
+      return notifyClient.getNotifications(templateType, status)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
-    it('should get all delivered sms notifications with a reference', function(done) {
+    it('should get all delivered sms notifications with a reference', () => {
 
       let templateType = 'sms';
       let status = 'delivered';
@@ -299,14 +290,13 @@ describe('notification api', function() {
       .get('/v2/notifications?template_type=' + templateType + '&status=' + status + '&reference=' + reference)
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.getNotifications(templateType, status, reference)
+      return notifyClient.getNotifications(templateType, status, reference)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
 
-    it('should get all failed email notifications with a reference older than a given notification', function(done) {
+    it('should get all failed email notifications with a reference older than a given notification', () => {
 
       let templateType = 'sms';
       let status = 'delivered';
@@ -321,17 +311,16 @@ describe('notification api', function() {
       )
       .reply(200, {hooray: 'bkbbk'});
 
-      notifyClient.getNotifications(templateType, status, reference, olderThanId)
+      return notifyClient.getNotifications(templateType, status, reference, olderThanId)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
     });
   });
 
   describe('template funtions', () => {
 
-    it('should get template by id', function(done) {
+    it('should get template by id', () => {
 
       let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
 
@@ -339,15 +328,14 @@ describe('notification api', function() {
       .get('/v2/template/' + templateId)
       .reply(200, {foo: 'bar'});
 
-      notifyClient.getTemplateById(templateId)
+      return notifyClient.getTemplateById(templateId)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
 
     });
 
-    it('should get template by id and version', function(done) {
+    it('should get template by id and version', () => {
 
       let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
       let version = 10;
@@ -356,29 +344,27 @@ describe('notification api', function() {
       .get('/v2/template/' + templateId + '/version/' + version)
       .reply(200, {foo: 'bar'});
 
-      notifyClient.getTemplateByIdAndVersion(templateId, version)
+      return notifyClient.getTemplateByIdAndVersion(templateId, version)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
 
     });
 
-    it('should get all templates with unspecified template type', function(done) {
+    it('should get all templates with unspecified template type', () => {
 
       notifyAuthNock
       .get('/v2/templates')
       .reply(200, {foo: 'bar'});
 
-      notifyClient.getAllTemplates()
+      return notifyClient.getAllTemplates()
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
 
     });
 
-    it('should get all templates with unspecified template type', function(done) {
+    it('should get all templates with unspecified template type', () => {
 
       let templateType = 'sms'
 
@@ -386,15 +372,14 @@ describe('notification api', function() {
       .get('/v2/templates?type=' + templateType)
       .reply(200, {foo: 'bar'});
 
-      notifyClient.getAllTemplates(templateType)
+      return notifyClient.getAllTemplates(templateType)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
 
     });
 
-    it('should preview template by id with personalisation', function(done) {
+    it('should preview template by id with personalisation', () => {
 
       let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
       let payload = {name: 'Foo' }
@@ -404,15 +389,14 @@ describe('notification api', function() {
         .post('/v2/template/' + templateId + '/preview', expectedPersonalisation)
         .reply(200, {foo: 'bar'});
 
-      notifyClient.previewTemplateById(templateId, payload)
+      return notifyClient.previewTemplateById(templateId, payload)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
-        done();
       });
 
     });
 
-    it('should preview template by id without personalisation', function(done) {
+    it('should preview template by id without personalisation', () => {
 
       let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
 
@@ -420,10 +404,9 @@ describe('notification api', function() {
       .post('/v2/template/' + templateId + '/preview')
       .reply(200, {foo: 'bar'});
 
-      notifyClient.previewTemplateById(templateId)
+      return notifyClient.previewTemplateById(templateId)
       .then(function (response) {
         expect(response .statusCode).to.equal(200);
-        done();
       });
     });
   });

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -99,7 +99,7 @@ describe('notification api', () => {
           reference: 'ABC123'
         };
       return notifyClient.sendEmail(templateId, email, options)
-        .catch((err) => expect(err.message).to.equal('Options ["firstname","surname"] not recognised'));
+        .catch((err) => expect(err.message).to.include('["firstname","surname"]'));
     });
   });
 
@@ -163,7 +163,7 @@ describe('notification api', () => {
           reference: 'ABC123'
         };
       return notifyClient.sendSms(templateId, phoneNumber, options)
-        .catch((err) => expect(err.message).to.equal('Options ["firstname","surname"] not recognised'));
+        .catch((err) => expect(err.message).to.include('["firstname","surname"]'));
     });
   });
 
@@ -204,7 +204,7 @@ describe('notification api', () => {
           reference: 'ABC123'
         };
       return notifyClient.sendLetter(templateId, options)
-        .catch((err) => expect(err.message).to.equal('Options ["address_line_1","address_line_2","postcode"] not recognised'));
+        .catch((err) => expect(err.message).to.include('["address_line_1","address_line_2","postcode"]'));
     });
 
   });

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -1,7 +1,8 @@
-var expect = require('chai').expect, NotifyClient = require('../client/notification.js').NotifyClient,
-    MockDate = require('mockdate'),
-    nock = require('nock'),
-    createGovukNotifyToken = require('../client/authentication.js');
+let expect = require('chai').expect,
+  NotifyClient = require('../client/notification.js').NotifyClient,
+  MockDate = require('mockdate'),
+  nock = require('nock'),
+  createGovukNotifyToken = require('../client/authentication.js');
 
 MockDate.set(1234567890000);
 
@@ -10,370 +11,386 @@ const serviceId = 'c745a8d8-b48a-4b0d-96e5-dbea0165ebd1';
 const apiKeyId = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3';
 
 function getNotifyClient() {
-    var baseUrl = 'http://localhost';
-    var notifyClient = new NotifyClient(baseUrl, serviceId, apiKeyId);
-    return notifyClient;
+  let baseUrl = 'http://localhost';
+  let notifyClient = new NotifyClient(baseUrl, serviceId, apiKeyId);
+  return notifyClient;
 }
 
 function getNotifyAuthNock() {
-    var notifyNock = nock(baseUrl, {
-        reqheaders: {
-            'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
-        }
-    })
-    return notifyNock;
+  let notifyNock = nock(baseUrl, {
+    reqheaders: {
+      'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
+    }
+  })
+  return notifyNock;
 }
 
 describe('notification api', function() {
 
-    beforeEach(function() {
-      MockDate.set(1234567890000);
-    });
+  beforeEach(function() {
+    MockDate.set(1234567890000);
+  });
 
-    afterEach(function() {
-      MockDate.reset();
-    });
+  afterEach(function() {
+    MockDate.reset();
+  });
 
-    var notifyClient = getNotifyClient();
-    var notifyAuthNock = getNotifyAuthNock();
+  let notifyClient = getNotifyClient();
+  let notifyAuthNock = getNotifyAuthNock();
 
+  describe('sendEmail', () => {
     it('should send an email', function(done) {
 
-        var email = 'dom@example.com',
-          templateId = '123',
-          options = {
-            personalisation: {foo: 'bar'},
-          },
-          data = {
-              template_id: templateId,
-              email_address: email,
-              personalisation: options.personalisation
-          };
+      let email = 'dom@example.com',
+        templateId = '123',
+        options = {
+          personalisation: {foo: 'bar'},
+        },
+        data = {
+          template_id: templateId,
+          email_address: email,
+          personalisation: options.personalisation
+        };
 
-        notifyAuthNock
-          .post('/v2/notifications/email', data)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .post('/v2/notifications/email', data)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.sendEmail(templateId, email, options)
-          .then(function (response) {
-            expect(response.statusCode).to.equal(200);
-            done();
-        });
+      notifyClient.sendEmail(templateId, email, options)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+
+    });
+
+    it('should send an email with email_reply_to_id', function() {
+
+      let email = 'dom@example.com',
+        templateId = '123',
+        options = {
+          personalisation: {foo: 'bar'},
+          emailReplyToId: '456',
+        },
+        data = {
+          template_id: templateId,
+          email_address: email,
+          personalisation: options.personalisation,
+          email_reply_to_id: options.emailReplyToId
+        };
+
+      notifyAuthNock
+      .post('/v2/notifications/email', data)
+      .reply(200, {hooray: 'bkbbk'});
+
+      return notifyClient.sendEmail(templateId, email, options)
+      .then((response) => {
+        expect(response.statusCode).to.equal(200);
+      });
 
     });
 
-    it('should send an email with email_reply_to_id', function(done) {
-      
-        var email = 'dom@example.com',
-          templateId = '123',
-          options = {
-            personalisation: {foo: 'bar'},
-            emailReplyToId: '456',
-          },
-          data = {
-              template_id: templateId,
-              email_address: email,
-              personalisation: options.personalisation,
-              email_reply_to_id: options.emailReplyToId
-          };
 
-        notifyAuthNock
-          .post('/v2/notifications/email', data)
-          .reply(200, {"hooray": "bkbbk"});
+  });
 
-        notifyClient.sendEmail(templateId, email, options)
-          .then(function (response) {
-            expect(response.statusCode).to.equal(200);
-            done();
-        });
-
-    });
+  describe('sendSms', () => {
 
     it('should send an sms', function(done) {
 
-        var phoneNo = '07525755555',
-          templateId = '123',
-          options = {
-            personalisation: {foo: 'bar'},
-          },
-          data = {
-              template_id: templateId,
-              phone_number: phoneNo,
-              personalisation: options.personalisation
-          };
+      let phoneNo = '07525755555',
+        templateId = '123',
+        options = {
+          personalisation: {foo: 'bar'},
+        },
+        data = {
+          template_id: templateId,
+          phone_number: phoneNo,
+          personalisation: options.personalisation
+        };
 
-        notifyAuthNock
-          .post('/v2/notifications/sms', data)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .post('/v2/notifications/sms', data)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.sendSms(templateId, phoneNo, options)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.sendSms(templateId, phoneNo, options)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
 
     it('should send an sms with smsSenderId', function(done) {
 
-        var phoneNo = '07525755555',
-          templateId = '123',
-          options = {
-            personalisation: {foo: 'bar'},
-            smsSenderId: '456',
-          },
-          data = {
-              template_id: templateId,
-              phone_number: phoneNo,
-              personalisation: options.personalisation,
-              sms_sender_id: options.smsSenderId,
-          };
+      let phoneNo = '07525755555',
+        templateId = '123',
+        options = {
+          personalisation: {foo: 'bar'},
+          smsSenderId: '456',
+        },
+        data = {
+          template_id: templateId,
+          phone_number: phoneNo,
+          personalisation: options.personalisation,
+          sms_sender_id: options.smsSenderId,
+        };
 
-        notifyAuthNock
-          .post('/v2/notifications/sms', data)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .post('/v2/notifications/sms', data)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.sendSms(templateId, phoneNo, options)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.sendSms(templateId, phoneNo, options)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
+
+
+  });
+
+  describe('sendLetter', () => {
 
     it('should send a letter', function(done) {
-      
-        var templateId = '123',
-          options = {
-            personalisation: {
-              address_line_1: 'Mr Tester',
-              address_line_2: '1 Test street',
-              postcode: 'NW1 2UN'
-            },
+
+      let templateId = '123',
+        options = {
+          personalisation: {
+            address_line_1: 'Mr Tester',
+            address_line_2: '1 Test street',
+            postcode: 'NW1 2UN'
           },
-          data = {
-              template_id: templateId,
-              personalisation: options.personalisation
-          };
+        },
+        data = {
+          template_id: templateId,
+          personalisation: options.personalisation
+        };
 
-        notifyAuthNock
-          .post('/v2/notifications/letter', data)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .post('/v2/notifications/letter', data)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.sendLetter(templateId, options)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.sendLetter(templateId, options)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
 
-    it('should get notification by id', function(done) {
+  });
 
-        var baseUrl = 'http://localhost',
-          notificationId = 'wfdfdgf';
+  it('should get notification by id', function(done) {
 
-        notifyAuthNock
-          .get('/v2/notifications/' + notificationId)
-          .reply(200, {"hooray": "bkbbk"});
+    let notificationId = 'wfdfdgf';
 
-        notifyClient.getNotificationById(notificationId)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
-    });
+    notifyAuthNock
+      .get('/v2/notifications/' + notificationId)
+      .reply(200, {hooray: 'bkbbk'});
+
+    notifyClient.getNotificationById(notificationId)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+  });
+
+  describe('getNotifications', () => {
 
     it('should get all notifications', function(done) {
 
-        notifyAuthNock
-          .get('/v2/notifications')
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .get('/v2/notifications')
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.getNotifications()
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getNotifications()
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
 
     it('should get all notifications with a reference', function(done) {
 
-        var reference = 'myref'
+      let reference = 'myref';
 
-        notifyAuthNock
-          .get('/v2/notifications?reference=' + reference)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .get('/v2/notifications?reference=' + reference)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.getNotifications(undefined, undefined, reference)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getNotifications(undefined, undefined, reference)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
 
     it('should get all failed notifications', function(done) {
 
-        var status = 'failed';
+      let status = 'failed';
 
-        notifyAuthNock
-          .get('/v2/notifications?status=' + status)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .get('/v2/notifications?status=' + status)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.getNotifications(undefined, 'failed')
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getNotifications(undefined, 'failed')
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
 
     it('should get all failed sms notifications', function(done) {
 
-        var templateType = 'sms'
-          status = 'failed';
+      let templateType = 'sms';
+      let status = 'failed';
 
-        notifyAuthNock
-          .get('/v2/notifications?template_type=' + templateType + '&status=' + status)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .get('/v2/notifications?template_type=' + templateType + '&status=' + status)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.getNotifications(templateType, status)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getNotifications(templateType, status)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
 
     it('should get all delivered sms notifications with a reference', function(done) {
 
-        var templateType = 'sms'
-          status = 'delivered';
-          reference = 'myref'
+      let templateType = 'sms';
+      let status = 'delivered';
+      let reference = 'myref';
 
-        notifyAuthNock
-          .get('/v2/notifications?template_type=' + templateType + '&status=' + status + '&reference=' + reference)
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .get('/v2/notifications?template_type=' + templateType + '&status=' + status + '&reference=' + reference)
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.getNotifications(templateType, status, reference)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getNotifications(templateType, status, reference)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
 
     it('should get all failed email notifications with a reference older than a given notification', function(done) {
 
-        var templateType = 'sms';
-          status = 'delivered';
-          reference = 'myref';
-          olderThanId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+      let templateType = 'sms';
+      let status = 'delivered';
+      let reference = 'myref';
+      let olderThanId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
 
-        notifyAuthNock
-          .get('/v2/notifications?template_type=' + templateType +
-               '&status=' + status +
-               '&reference=' + reference +
-               '&older_than=' + olderThanId
-              )
-          .reply(200, {"hooray": "bkbbk"});
+      notifyAuthNock
+      .get('/v2/notifications?template_type=' + templateType +
+        '&status=' + status +
+        '&reference=' + reference +
+        '&older_than=' + olderThanId
+      )
+      .reply(200, {hooray: 'bkbbk'});
 
-        notifyClient.getNotifications(templateType, status, reference, olderThanId)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getNotifications(templateType, status, reference, olderThanId)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
     });
+  });
+
+  describe('template funtions', () => {
 
     it('should get template by id', function(done) {
 
-        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+      let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
 
-        notifyAuthNock
-          .get('/v2/template/' + templateId)
-          .reply(200, {"foo": "bar"});
+      notifyAuthNock
+      .get('/v2/template/' + templateId)
+      .reply(200, {foo: 'bar'});
 
-        notifyClient.getTemplateById(templateId)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getTemplateById(templateId)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
 
     });
 
     it('should get template by id and version', function(done) {
 
-        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
-          version = 10;
+      let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+      let version = 10;
 
-        notifyAuthNock
-          .get('/v2/template/' + templateId + '/version/' + version)
-          .reply(200, {"foo": "bar"});
+      notifyAuthNock
+      .get('/v2/template/' + templateId + '/version/' + version)
+      .reply(200, {foo: 'bar'});
 
-        notifyClient.getTemplateByIdAndVersion(templateId, version)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
-
-    });
-
-    it('should get all templates with unspecified template type', function(done) {
-
-        notifyAuthNock
-          .get('/v2/templates')
-          .reply(200, {"foo": "bar"});
-
-        notifyClient.getAllTemplates()
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.getTemplateByIdAndVersion(templateId, version)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
 
     });
 
     it('should get all templates with unspecified template type', function(done) {
 
-        var templateType = 'sms'
+      notifyAuthNock
+      .get('/v2/templates')
+      .reply(200, {foo: 'bar'});
 
-        notifyAuthNock
-          .get('/v2/templates?type=' + templateType)
-          .reply(200, {"foo": "bar"});
+      notifyClient.getAllTemplates()
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
 
-        notifyClient.getAllTemplates(templateType)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+    });
+
+    it('should get all templates with unspecified template type', function(done) {
+
+      let templateType = 'sms'
+
+      notifyAuthNock
+      .get('/v2/templates?type=' + templateType)
+      .reply(200, {foo: 'bar'});
+
+      notifyClient.getAllTemplates(templateType)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
 
     });
 
     it('should preview template by id with personalisation', function(done) {
 
-        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
-          payload = { "name": "Foo" }
-          expectedPersonalisation = { "personalisation" : payload };
+      let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+      let payload = {name: 'Foo' }
+      let expectedPersonalisation = {personalisation: payload };
 
-        notifyAuthNock
-          .post('/v2/template/' + templateId + '/preview', expectedPersonalisation)
-          .reply(200, {"foo": "bar"});
+      notifyAuthNock
+        .post('/v2/template/' + templateId + '/preview', expectedPersonalisation)
+        .reply(200, {foo: 'bar'});
 
-        notifyClient.previewTemplateById(templateId, payload)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.previewTemplateById(templateId, payload)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
 
     });
 
     it('should preview template by id without personalisation', function(done) {
 
-        var templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
+      let templateId = '35836a9e-5a97-4d99-8309-0c5a2c3dbc72';
 
-        notifyAuthNock
-          .post('/v2/template/' + templateId + '/preview')
-          .reply(200, {"foo": "bar"});
+      notifyAuthNock
+      .post('/v2/template/' + templateId + '/preview')
+      .reply(200, {foo: 'bar'});
 
-        notifyClient.previewTemplateById(templateId)
-          .then(function (response) {
-              expect(response.statusCode).to.equal(200);
-              done();
-          });
+      notifyClient.previewTemplateById(templateId)
+      .then(function (response) {
+        expect(response .statusCode).to.equal(200);
+      });
     });
+  });
 
 });
 

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -90,7 +90,18 @@ describe('notification api', function() {
 
     });
 
-
+    it('should reject options dicts with unknown options', () => {
+      let email = 'foo@bar.com',
+        templateId = '123',
+        // old personalisation dict
+        options = {
+          firstname: 'Fred',
+          surname: 'Smith',
+          reference: 'ABC123'
+        };
+      return notifyClient.sendEmail(templateId, email, options)
+        .catch((err) => expect(err.message).to.equal('Options ["firstname","surname"] not recognised'));
+    });
   });
 
   describe('sendSms', () => {
@@ -145,7 +156,18 @@ describe('notification api', function() {
       });
     });
 
-
+    it('should reject options dicts with unknown options', () => {
+      let phoneNumber = '07123456789',
+        templateId = '123',
+        // old personalisation dict
+        options = {
+          firstname: 'Fred',
+          surname: 'Smith',
+          reference: 'ABC123'
+        };
+      return notifyClient.sendSms(templateId, phoneNumber, options)
+        .catch((err) => expect(err.message).to.equal('Options ["firstname","surname"] not recognised'));
+    });
   });
 
   describe('sendLetter', () => {
@@ -174,6 +196,19 @@ describe('notification api', function() {
         expect(response.statusCode).to.equal(200);
         done();
       });
+    });
+
+    it('should reject options dicts with unknown options', () => {
+      let templateId = '123',
+        // old personalisation dict
+        options = {
+          address_line_1: 'Mr Tester',
+          address_line_2: '1 Test street',
+          postcode: 'NW1 2UN',
+          reference: 'ABC123'
+        };
+      return notifyClient.sendLetter(templateId, options)
+        .catch((err) => expect(err.message).to.equal('Options ["address_line_1","address_line_2","postcode"] not recognised'));
     });
 
   });
@@ -388,6 +423,7 @@ describe('notification api', function() {
       notifyClient.previewTemplateById(templateId)
       .then(function (response) {
         expect(response .statusCode).to.equal(200);
+        done();
       });
     });
   });


### PR DESCRIPTION
With the breaking change in version 4.0.0, we reduced the amount of parameters by asking that they are supplied in an options dict.

However, this can silently do unexpected things if the person was previously passing in a personalisation dict, and forgets to update their call. We can't catch 100% of those errors, but we can catch obvious things, like the options dict containing things we don't expect.

Also, lots of linter errors and test refactoring. Viewing commit by commit with whitespace off highly recommended!