### PR TITLE
Make integration tests expect \r in template content

### DIFF
--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -130,7 +130,7 @@ describer('notification api with a live service', () => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getNotificationJson);
         response.body.type.should.equal('email');
-        response.body.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
+        response.body.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
         response.body.subject.should.equal('Functional Tests are good');
       });
     });
@@ -141,7 +141,7 @@ describer('notification api with a live service', () => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getNotificationJson);
         response.body.type.should.equal('sms');
-        response.body.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
+        response.body.body.should.equal('Hello Foo\r\n\r\nFunctional Tests make our world a better place');
       });
     });
 

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -62,7 +62,7 @@ describer('notification api with a live service', () => {
       return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
+        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
         response.body.content.subject.should.equal('Functional Tests are good');
         response.body.reference.should.equal(clientRef);
         emailNotificationId = response.body.id;
@@ -77,7 +77,7 @@ describer('notification api with a live service', () => {
       return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\n\nFunctional test help make our world a better place');
+        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
         response.body.content.subject.should.equal('Functional Tests are good');
         response.body.reference.should.equal(clientRef);
         emailNotificationId = response.body.id;
@@ -91,7 +91,7 @@ describer('notification api with a live service', () => {
       return notifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
+        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional Tests make our world a better place');
         smsNotificationId = response.body.id;
       });
     });
@@ -104,7 +104,7 @@ describer('notification api with a live service', () => {
       return notifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
+        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional Tests make our world a better place');
         smsNotificationId = response.body.id;
       });
     });

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -183,7 +183,7 @@ describer('notification api with a live service', () => {
       return notifyClient.getTemplateById(emailTemplateId).then((response) => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplateJson);
-        response.body.body.should.equal('Hello ((name))\n\nFunctional test help make our world a better place');
+        response.body.body.should.equal('Hello ((name))\r\n\r\nFunctional test help make our world a better place');
         response.body.subject.should.equal('Functional Tests are good');
       });
     });


### PR DESCRIPTION
previously templates table has \n but no \r, we now read from templates_history which has \r\n, so should update test. templates table should also really have \r as well.
