### PR TITLE
Add typings to the NotifyClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.1.2] - 2018-07-11
+
+### Changed
+
+* Added types definitions for those of use TypeScript <3
+
 ## [4.1.0] - 2017-11-23
 
 ### Changed

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,139 @@
+export type TemplateType = 'all' | 'email' | 'sms' | 'letter';
+
+export interface Notification {
+  readonly id: string;
+  readonly body: string;
+  readonly subject: string;
+  readonly reference: string;
+  readonly email_address: string;
+  readonly phone_number: string;
+  readonly line_1: string;
+  readonly line_2: string;
+  readonly line_3: string;
+  readonly line_4: string;
+  readonly line_5: string;
+  readonly line_6: string;
+  readonly postcode: string;
+  readonly type: TemplateType;
+  readonly status: string;
+  readonly template: {
+      readonly version: number;
+      readonly id: number;
+      readonly uri: string;
+   },
+  readonly created_at: string;
+  readonly sent_at: string;
+}
+
+export interface Template {
+  readonly id: string;
+  readonly type: TemplateType;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly version: number;
+  readonly created_by: string;
+  readonly body: string;
+  readonly subject: string | null;
+}
+
+export interface ItterableResponse {
+  readonly links: {
+    readonly current: string;
+    readonly previous: string;
+    readonly next: string;
+  };
+}
+
+export interface NotificationsResponse extends ItterableResponse {
+  readonly notifications: ReadonlyArray<Notification>;
+}
+
+export interface TemplatesResponse extends ItterableResponse {
+  readonly templates: ReadonlyArray<Template>;
+}
+
+export interface ReceivedTextMessages extends ItterableResponse {
+  readonly received_text_messages: ReadonlyArray<{
+    readonly id: string;
+    readonly user_number: string;
+    readonly notify_number: string;
+    readonly created_at: string;
+    readonly service_id: string;
+    readonly content: string;
+  }>;
+}
+
+export interface ErrorResponse {
+  readonly error: string;
+  readonly message: string;
+}
+
+interface GeneralResponse {
+  readonly id: string;
+  readonly reference: string | null;
+  readonly content: {
+      readonly body: string;
+  };
+  readonly uri: string;
+  readonly template: {
+      readonly id: string;
+      readonly version: number;
+      readonly uri: string;
+  };
+}
+
+export interface EmailResponse extends GeneralResponse {
+  readonly content: {
+    readonly body: string;
+    readonly from_email: string;
+    readonly subject: string;
+  };
+}
+
+export interface SmsResponse extends GeneralResponse {
+  readonly content: {
+    readonly body: string;
+    readonly from_number: string;
+  };
+}
+
+export interface LetterResponse extends GeneralResponse {
+  readonly content: {
+    readonly body: string;
+    readonly subject: string;
+  };
+  readonly scheduled_for: string | null;
+}
+
+export interface RequestOptions {
+  personalisation?: object,
+  reference?: string,
+  emailReplyToId?: string,
+}
+
+export interface RequestLetterOptions extends RequestOptions {
+  personalisation: {
+    readonly address_line_1: string;
+    readonly address_line_2: string;
+    readonly postcode: string;
+    readonly application_id: string;
+    readonly application_date: string;
+
+    readonly [option: string]: string;
+  },
+}
+
+export class NotifyClient {
+  constructor(apiKey: string);
+  sendEmail(templateID: string, email: string, options?: RequestOptions): Promise<EmailResponse>;
+  sendSms(templateID: string, phoneNumber: string, options?: RequestOptions): Promise<SmsResponse>;
+  sendLetter(templateID: string, options: RequestLetterOptions): Promise<LetterResponse>;
+  getNotificationById(notificationID: string): Promise<Notification>;
+  getNotifications(templateType?: TemplateType, status?: string, reference?: string, olderThanID?: string): Promise<NotificationsResponse>;
+  getTemplateById(templateID: string): Promise<Template>;
+  getTemplateByIdAndVersion(templateID: string, version: number): Promise<Template>;
+  getAllTemplates(templateType: TemplateType): Promise<TemplatesResponse>;
+  previewTemplateById(templateID: string, personalisation: object): Promise<Template>;
+  getReceivedTexts(olderThan: string): Promise<ReceivedTextMessages>;
+  setProxy(url: string): void;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.1",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "./node_modules/.bin/mocha \"spec/**/*.js\"",
     "integration": "./node_modules/.bin/mocha spec/integration/test.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "notifications-node-client",
   "version": "4.2.1",
-  "version": "4.2.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/spec/notification.ts
+++ b/spec/notification.ts
@@ -1,0 +1,88 @@
+import { NotifyClient } from "..";
+
+/**
+ * This isn't an actual test file. Its purpose is to demonstrate the use of 
+ * types with no issues.
+ */
+
+(async () => {
+  const client = new NotifyClient('__TEST_API_KEY__');
+
+  client.setProxy('__SAPLE_PROXY__');
+
+  const email1 = await client.sendEmail('__SAMPLE_TEMPLATE_ID__', 'test@example.com');
+  const email2 = await client.sendEmail('__SAMPLE_TEMPLATE_ID__', 'test@example.com', {
+    personalisation: {
+      firstName: 'Jeff',
+      lastName: 'Jefferson',
+    },
+  });
+
+  email1.content.body;
+  email2.reference;
+
+  const sms1 = await client.sendSms('__SAMPLE_TEMPLATE_ID__', '00000000000');
+  const sms2 = await client.sendSms('__SAMPLE_TEMPLATE_ID__', '00000000000', {
+    personalisation: {
+      firstName: 'Jeff',
+      lastName: 'Jefferson',
+    },
+  });
+
+  sms1.content.body;
+  sms2.reference;
+
+  const letter = await client.sendLetter('__SAMPLE_TEMPLATE_ID__', {
+    personalisation: {
+      address_line_1: '__SAMPLE_LETTER_DATA__',
+      address_line_2: '__SAMPLE_LETTER_DATA__',
+      postcode: '__SAMPLE_LETTER_DATA__',
+      application_id: '__SAMPLE_LETTER_DATA__',
+      application_date: '__SAMPLE_LETTER_DATA__',
+
+      firstName: 'Jeff',
+      lastName: 'Jefferson',
+    },
+  });
+
+  letter.content.body;
+
+  const notification = await client.getNotificationById('__TEST_NOTIFICATION_ID__');
+
+  notification.body;
+
+  const notifications1 = await client.getNotifications();
+  const notifications2 = await client.getNotifications('all');
+  const notifications3 = await client.getNotifications('all', 'sent');
+  const notifications4 = await client.getNotifications('all', 'sent', '__SAMPLE_REFERANCE__');
+  const notifications5 = await client.getNotifications('all', 'sent', '__SAMPLE_REFERANCE__', '__SAMPLE_TIMESTAMP__');
+
+  for (const n of notifications1.notifications) { n.type; }
+  for (const n of notifications2.notifications) { n.body; }
+  for (const n of notifications3.notifications) { n.created_at; }
+  for (const n of notifications4.notifications) { n.email_address; }
+  for (const n of notifications5.notifications) { n.status; }
+
+  const template1 = await client.getTemplateById('__SAMPLE_TEMPLATE_ID__');
+
+  template1.type;
+
+  const template2 = await client.getTemplateByIdAndVersion('__SAMPLE_TEMPLATE_ID__', 5);
+
+  template2.version === 5;
+
+  const templates = await client.getAllTemplates('email');
+
+  for (const t of templates.templates) { t.version; }
+
+  const previewTemplate = await client.previewTemplateById('__SAMPLE_TEMPLATE_ID__', {
+    firstName: 'Jeff',
+    lastName: 'Jefferson',
+  });
+
+  previewTemplate.version;
+
+  const receivedText = await client.getReceivedTexts('__SAMPLE_TIMESTAMP__');
+
+  for (const r of receivedText.received_text_messages) { r.notify_number; }
+});


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?

I'm introducing types for TypeScirpt to mainly satisfy the linters and
compilers, but also to provide extra code documentation that can be
previewed on the fly.

PaaS is using Notify and TypeScript for some their applications. Thus
far, we got around with typings in our local repo but I think other
teams that might be using TypeScript could benefit from this.

There is one extra file, which isn't actually a `spec`, but rather proof
that the types work as expected.

## Checklist

- [x] I’ve used the pull request template
- [ ] ~~I’ve written unit tests for these changes~~ I did the types test if that helps :D
- [x] I’ve updated the documentation in
  - `README.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] ~~I've added new environment variables in~~
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
