### PR TITLE
Add 'created_by_name' to the responses when getting notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.2.0] - 2018-07-24
+
+### Changed
+
+* Added `created_by_name` to the response for `.getNotificationById()` and `.getNotifications()`:
+    * If the notification was sent manually this will be the name of the sender. If the notification was sent through the API this will be `null`.
+
 ## [4.1.0] - 2017-11-23
 
 ### Changed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -418,6 +418,7 @@ If the request is successful, `response` will be an `object`:
         "id": 1,
         "uri": "/template/{id}/{version}"
      },
+    "created_by_name": "name of the person who sent the notification if sent manually",
     "created_at": "created at",
     "sent_at": "sent to provider at",
 }
@@ -494,6 +495,7 @@ Click here to expand for more information.
           "id": 1,
           "uri": "/template/{id}/{version}"
        },
+       "created_by_name": "name of the person who sent the notification if sent manually",
        "created_at": "created at",
        "sent_at": "sent to provider at",
     },

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ If the request is successful, `response` will be an `object`:
         "id": 1,
         "uri": "/template/{id}/{version}"
      },
+    "created_by_name": "name of the person who sent the notification if sent manually",
     "created_at": "created at",
     "sent_at": "sent to provider at",
 }
@@ -494,6 +495,7 @@ Click here to expand for more information.
           "id": 1,
           "uri": "/template/{id}/{version}"
        },
+       "created_by_name": "name of the person who sent the notification if sent manually",
        "created_at": "created at",
        "sent_at": "sent to provider at",
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/spec/integration/schemas/v2/GET_notification_response.json
+++ b/spec/integration/schemas/v2/GET_notification_response.json
@@ -21,6 +21,7 @@
         "body": {"type": "string"},
         "subject": {"type": ["string", "null"]},
         "created_at": {"type": "string"},
+        "created_by_name": {"type": ["string", "null"]},
         "sent_at": {"type": ["string", "null"]},
         "completed_at": {"type": ["string", "null"]},
         "scheduled_for": {"oneOf":[
@@ -31,6 +32,6 @@
     "required": [
         "id", "reference", "email_address", "phone_number",
         "line_1", "line_2", "line_3", "line_4", "line_5", "line_6", "postcode",
-        "type", "status", "template", "created_at", "sent_at", "completed_at"
+        "type", "status", "template", "created_at", "created_by_name", "sent_at", "completed_at"
     ]
 }


### PR DESCRIPTION
The `.getNotificationById()` and `.getNotifications()` functions now return `created_by_name` in their responses, so this has been documented and the schema for the integration tests updated.

The version has been bumped from 4.1.0 to 4.2.0 as a result. (Although the `package.json` was previously updated to 4.1.1 in #47, it appears that 4.1.1 was never released - the latest version on NPM is still 4.1.0)