### PR TITLE
Return 'name' when fetching a template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.3.0] - 2018-09-04
+
+* Added `name` to the response for `getTemplateById()` and `getTemplateByIdAndVersion()`
+    * These functions now return the name of the template as set in Notify
+
 ## [4.2.0] - 2018-07-24
 
 ### Changed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -611,6 +611,7 @@ Click here to expand for more information.
 ```javascript
 {
     "id": "template_id",
+    "name": "template name",
     "type": "sms|email|letter",
     "created_at": "created at",
     "updated_at": "updated at",
@@ -676,6 +677,7 @@ Click here to expand for more information.
 ```javascript
 {
     "id": "template_id",
+    "name": "template name",
     "type": "sms|email|letter",
     "created_at": "created at",
     "updated_at": "updated at",
@@ -746,6 +748,7 @@ Click here to expand for more information.
     "templates" : [
         {
             "id": "template_id",
+            "name": "template name",
             "type": "sms|email|letter",
             "created_at": "created at",
             "updated_at": "updated at",

--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ Click here to expand for more information.
 ```javascript
 {
     "id": "template_id",
+    "name": "template name",
     "type": "sms|email|letter",
     "created_at": "created at",
     "updated_at": "updated at",
@@ -676,6 +677,7 @@ Click here to expand for more information.
 ```javascript
 {
     "id": "template_id",
+    "name": "template name",
     "type": "sms|email|letter",
     "created_at": "created at",
     "updated_at": "updated at",
@@ -746,6 +748,7 @@ Click here to expand for more information.
     "templates" : [
         {
             "id": "template_id",
+            "name": "template name",
             "type": "sms|email|letter",
             "created_at": "created at",
             "updated_at": "updated at",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/spec/integration/schemas/v2/GET_template_by_id.json
+++ b/spec/integration/schemas/v2/GET_template_by_id.json
@@ -5,6 +5,7 @@
     "title": "reponse v2/template",
     "properties": {
         "id": {"$ref": "definitions.json#/uuid"},
+        "name": {"type": "string"},
         "type": {"enum": ["sms", "email", "letter"] },
         "created_at": {
             "format": "date-time",
@@ -21,5 +22,5 @@
         "body": {"type": "string"},
         "subject": {"type": ["string", "null"]}
     },
-    "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body"]
+    "required": ["id", "name", "type", "created_at", "updated_at", "version", "created_by", "body"]
 }

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -184,6 +184,7 @@ describer('notification api with a live service', function () {
       return notifyClient.getTemplateById(smsTemplateId).then((response) => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplateJson);
+        response.body.name.should.equal('Client Functional test sms template');
         should.not.exist(response.body.subject);
       });
     });
@@ -193,6 +194,7 @@ describer('notification api with a live service', function () {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplateJson);
         response.body.body.should.equal('Hello ((name))\r\n\r\nFunctional test help make our world a better place');
+        response.body.name.should.equal('Client Functional test email template');
         response.body.subject.should.equal('Functional Tests are good');
       });
     });
@@ -202,6 +204,7 @@ describer('notification api with a live service', function () {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplateJson);
         response.body.body.should.equal('Hello ((address_line_1))');
+        response.body.name.should.equal('Client functional letter template');
         response.body.subject.should.equal('Main heading');
       });
     });
@@ -210,6 +213,7 @@ describer('notification api with a live service', function () {
       return notifyClient.getTemplateByIdAndVersion(smsTemplateId, 1).then((response) => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplateJson);
+        response.body.name.should.equal('Example text message template');
         should.not.exist(response.body.subject);
         response.body.version.should.equal(1);
       });
@@ -219,6 +223,7 @@ describer('notification api with a live service', function () {
       return notifyClient.getTemplateByIdAndVersion(emailTemplateId, 1).then((response) => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplateJson);
+        response.body.name.should.equal('Client Functional test email template');
         response.body.version.should.equal(1);
       });
     });
@@ -227,6 +232,7 @@ describer('notification api with a live service', function () {
       return notifyClient.getTemplateByIdAndVersion(letterTemplateId, 1).then((response) => {
         response.statusCode.should.equal(200);
         expect(response.body).to.be.jsonSchema(getTemplateJson);
+        response.body.name.should.equal('Untitled');
         response.body.version.should.equal(1);
       });
     });


### PR DESCRIPTION
The name of the template is now returned by these two functions:
* `getTemplateById()`
* `getTemplateByIdAndVersion()`

No changes to the code are necessary to make this work, but this PR updates the documentation, adds integration tests and bumps the version.

[Pivotal story](https://www.pivotaltracker.com/story/show/160020331)
