### PR TITLE
Enable setting postage when sending precompiled letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## [4.6.0] - 2019-02-01
+
+### Changed
+
+* Added an optional postage argument to `sendPrecompiledLetter`
+
 ## [4.5.2] - 2018-11-05
 
 ### Changed
 
-* Moved documenation to https://docs.notifications.service.gov.uk/node.html (generated from DOCUMENTATION.md)
+* Moved documentation to https://docs.notifications.service.gov.uk/node.html (generated from DOCUMENTATION.md)
 
 ## [4.5.1] - 2018-09-14
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -488,10 +488,6 @@ A unique identifier you create. This reference identifies a single unique notifi
 "your_reference_here"
 ```
 
-#### postage (optional)
-
-You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
-
 #### pdfFile
 
 The precompiled letter must be a PDF file. For example:
@@ -508,6 +504,11 @@ fs.readFile('path/to/document.pdf', function (err, pdfFile) {
   )
 })
 ```
+
+#### postage (optional)
+
+You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
+
 
 ### Response
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -473,7 +473,8 @@ This is an invitation-only feature. Contact the GOV.UK Notify team on the [suppo
 ```javascript
 var response = notifyClient.sendPrecompiledLetter(
   reference,
-  pdfFile
+  pdfFile,
+  postage
 )
 ```
 
@@ -486,6 +487,10 @@ A unique identifier you create. This reference identifies a single unique notifi
 ```
 "your_reference_here"
 ```
+
+#### postage (optional)
+
+You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
 
 #### pdfFile
 
@@ -511,7 +516,8 @@ If the request to the client is successful, the promise resolves with an `object
 ```javascript
 {
   'id': '740e5834-3a29-46b4-9a6f-16142fde533a',
-  'reference': 'your-letter-reference'
+  'reference': 'your-letter-reference',
+  'postage': 'second'
 }
 ```
 
@@ -524,6 +530,7 @@ If the request is not successful, the promise fails with an `err`.
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation address_line_1 is a required property"`<br>`}]`|Send a valid PDF file|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Service is not allowed to send precompiled letters"`<br>`}]`|Contact the GOV.UK Notify team|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
@@ -618,6 +625,7 @@ If the request to the client is successful, the promise resolves with an `object
   'line_5': 'Some county',
   'line_6': 'Something else',
   'postcode': 'postcode',
+  'postage': 'first or second',
   'type': 'sms|letter|email',
   'status': 'current status',
   'template': {
@@ -731,6 +739,7 @@ If the request to the client is successful, the promise resolves with an `object
       'line_5': 'Some county',
       'line_6': 'Something else',
       'postcode': 'postcode',
+      'postage': 'first or second',
       'type': 'sms | letter | email',
       'status': 'sending | delivered | permanent-failure | temporary-failure | technical-failure',
       'template': {

--- a/client/notification.js
+++ b/client/notification.js
@@ -197,11 +197,15 @@ _.extend(NotifyClient.prototype, {
       createNotificationPayload('letter', templateId, undefined, personalisation, reference));
   },
 
-  sendPrecompiledLetter: function(reference, pdf_file) {
+  sendPrecompiledLetter: function(reference, pdf_file, postage) {
+    var postage = postage || undefined
     content = _check_and_encode_file(pdf_file, 5)
     notification = {
       "reference": reference,
       "content": content
+    }
+    if (postage != undefined) {
+      notification["postage"] = postage
     }
     return this.apiClient.post('/v2/notifications/letter', notification);
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/spec/integration/schemas/v2/GET_notification_response.json
+++ b/spec/integration/schemas/v2/GET_notification_response.json
@@ -15,6 +15,7 @@
         "line_5": {"type": ["string", "null"]},
         "line_6": {"type": ["string", "null"]},
         "postcode": {"type": ["string", "null"]},
+        "postage": {"type": ["string", "null"]},
         "type": {"enum": ["sms", "letter", "email"]},
         "status": {"type": "string"},
         "template": {"$ref": "definitions.json#/template"},

--- a/spec/integration/schemas/v2/POST_notification_letter_response.json
+++ b/spec/integration/schemas/v2/POST_notification_letter_response.json
@@ -5,6 +5,7 @@
     "properties": {
         "id": {"$ref": "definitions.json#/uuid"},
         "reference": {"type": ["string", "null"]},
+        "postage": {"type": "string"},
         "content": {"$ref": "definitions.json#/letter_content"},
         "uri": {"type": "string"},
         "template": {"$ref": "definitions.json#/template"},

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -149,7 +149,7 @@ describer('notification api with a live service', function () {
       var fs = require('fs');
       fs.readFile('./spec/integration/test_files/one_page_pdf.pdf', function(err, pdf_file) {
         console.log(err);
-        return notifyClient.sendPrecompiledLetter("my_reference", pdf_file)
+        return notifyClient.sendPrecompiledLetter("my_reference", pdf_file, "first")
         .then((response) => {
           response.statusCode.should.equal(201);
           expect(response.body).to.be.jsonSchema(postLetterNotificationResponseJson);

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -273,6 +273,23 @@ describe('notification api', () => {
       });
     });
 
+
+    it('should be able to set postage when sending a precompiled letter', () => {
+      let pdf_file = Buffer.from("%PDF-1.5 testpdf"),
+      reference = "HORK",
+      postage = "first"
+      data = {"reference": reference, "content": pdf_file.toString('base64'), "postage": postage}
+
+      notifyAuthNock
+      .post('/v2/notifications/letter', data)
+      .reply(200, {hiphip: 'hooray'});
+
+      return notifyClient.sendPrecompiledLetter(reference, pdf_file, postage)
+      .then(function (response) {
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
     it('should throw error when file bigger than 5MB is supplied', () => {
       let file = Buffer.alloc(6*1024*1024),
       reference = "HORK"


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Users will be able to postage when sending precompiled letters

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
