### PR TITLE
Link to precompiled letter specification from docs

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -490,7 +490,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 
 #### pdfFile
 
-The precompiled letter must be a PDF file which meets [the specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf). For example:
+The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf). For example:
 
 ```javascript
 var fs = require('fs')
@@ -577,7 +577,7 @@ You can only get the status of messages that are 7 days old or newer.
 |:---|:---|
 |Pending virus check|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|Validation failed|Content in the precompiled letter file is outside the printable area. [See the letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf) for more information. |
+|Validation failed|Content in the precompiled letter file is outside the printable area. [See the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf) for more information. |
 
 ## Get the status of one message
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -490,7 +490,7 @@ A unique identifier you create. This reference identifies a single unique notifi
 
 #### pdfFile
 
-The precompiled letter must be a PDF file. For example:
+The precompiled letter must be a PDF file which meets [the specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf). For example:
 
 ```javascript
 var fs = require('fs')
@@ -577,7 +577,7 @@ You can only get the status of messages that are 7 days old or newer.
 |:---|:---|
 |Pending virus check|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |Virus scan failed|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|Validation failed|Content in the precompiled letter file is outside the printable area.|
+|Validation failed|Content in the precompiled letter file is outside the printable area. [See the letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf) for more information. |
 
 ## Get the status of one message
 


### PR DESCRIPTION
This will make it less likely that people need to ask us to send them the specification manually.

File is deployed here: https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.3.pdf

Question:
- should we link to the specific version, or link to a filename like notify-pdf-letter-spec-LATEST.pdf

