### PR TITLE
Fix node client integration tests on Jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,9 @@
-FROM node:6.5.0-slim
-
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
-ARG NO_PROXY
+FROM node:10.16.3-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY etc/apt/sources.list /etc/apt/sources.list
-
 RUN \
 	echo "Install base packages" \
-	&& ([ -z "$HTTP_PROXY" ] || echo "Acquire::http::Proxy \"${HTTP_PROXY}\";" > /etc/apt/apt.conf.d/99HttpProxy) \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		make \


### PR DESCRIPTION
Recently, we have changed the Dockerfile in this repo, so it conforms
with our new Concourse pipeline. Yet, this made it incompatible with
Jenkins, and it turned out we are still running integration tests
on Jenkins when deploying the API.
So now we will have two Dockerfiles to help both Concourse and
Jenkins jobs run smoothly in the transition period.