### PR TITLE
Get letter pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.7.0] - 2019-02-01
+
+### Changed
+
+* Add `notifyClient.getPdfForLetterNotification(notificationId)`
+    * Returns a Buffer with pdf data
+    * Will raise a BadRequestError if the PDF is not available
+
 ## [4.6.0] - 2019-02-01
 
 ### Changed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -776,6 +776,59 @@ If the request is not successful, the promise fails with an `err`.
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
 
+## Get a PDF for a letter notification
+
+### Method
+
+```javascript
+notifyClient
+  .getPdfForLetterNotification(notificationId)
+  .then(function(fileBuffer) {
+    return fileBuffer
+  })  /* the response is a file buffer ,an instance of Buffer */
+  .catch((err) => console.error(err))
+
+```
+
+The method returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) [external link]. The promise will either:
+
+- resolve with `fileBuffer` if successful
+- fail with an `err` if unsuccessful
+
+### Arguments
+
+#### notification_id (required)
+
+The ID of the notification. You can find the notification ID in the response to the [original notification method call](/python.html#get-the-status-of-one-message-response).
+
+You can also find it in your [GOV.UK Notify Dashboard](https://www.notifications.service.gov.uk).
+
+1. Sign into GOV.UK Notify and select __Dashboard__.
+1. Select __letters sent__.
+1. Select the relevant notification.
+1. Copy the notification ID from the end of the page URL, for example `https://www.notifications.service.gov.uk/services/af90d4cb-ae88-4a7c-a197-5c30c7db423b/notification/ID`.
+
+### Response
+
+If the request to the client is successful, the client will return an instance of the [Buffer](https://nodejs.org/api/buffer.html#buffer_buffer) class containing the raw PDF data.
+
+### Error codes
+
+If the request is not successful, the client will return an `HTTPError` containing the relevant error code:
+
+|error.status_code|error.message|How to fix|
+|:---|:---|:---|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
+|`400`|`[{`<br>`"error": "PDFNotReadyError",`<br>`"message": "PDF not available yet, try again later"`<br>`}]`|Wait for the notification to finish processing. This usually takes a few seconds|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Document did not pass the virus scan"`<br>`}]`|You cannot retrieve the contents of a letter notification that contains a virus|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "PDF not available for letters in technical-failure"`<br>`}]`|You cannot retrieve the contents of a letter notification in technical-failure|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Notification is not a letter"`<br>`}]`|Check that you are looking up the correct notification|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
+|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
+
+
+
 # Get a template
 
 ## Get a template by ID

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -783,11 +783,10 @@ If the request is not successful, the promise fails with an `err`.
 ```javascript
 notifyClient
   .getPdfForLetterNotification(notificationId)
-  .then(function(fileBuffer) {
+  .then(function (fileBuffer) {
     return fileBuffer
-  })  /* the response is a file buffer ,an instance of Buffer */
+  }) /* the response is a file buffer, an instance of Buffer */
   .catch((err) => console.error(err))
-
 ```
 
 The method returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) [external link]. The promise will either:

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -800,12 +800,7 @@ The method returns a [promise](https://developer.mozilla.org/en-US/docs/Web/Java
 
 The ID of the notification. You can find the notification ID in the response to the [original notification method call](/python.html#get-the-status-of-one-message-response).
 
-You can also find it in your [GOV.UK Notify Dashboard](https://www.notifications.service.gov.uk).
-
-1. Sign into GOV.UK Notify and select __Dashboard__.
-1. Select __letters sent__.
-1. Select the relevant notification.
-1. Copy the notification ID from the end of the page URL, for example `https://www.notifications.service.gov.uk/services/af90d4cb-ae88-4a7c-a197-5c30c7db423b/notification/ID`.
+You can also find it by signing in to [GOV.UK Notify](https://www.notifications.service.gov.uk) and going to the __API integration__ page.
 
 ### Response
 

--- a/client/api_client.js
+++ b/client/api_client.js
@@ -64,7 +64,7 @@ _.extend(ApiClient.prototype, {
    *
    * @returns {Promise}
    */
-  get: function(path) {
+  get: function(path, additionalOptions) {
     var options = {
       method: 'GET',
       uri: this.urlBase + path,
@@ -75,25 +75,7 @@ _.extend(ApiClient.prototype, {
         'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version
       }
     };
-
-    if(this.proxy !== null) options.proxy = this.proxy;
-
-    return restClient(options);
-  },
-
-  getPdf: function(path) {
-    var options = {
-      method: 'GET',
-      uri: this.urlBase + path,
-      json: true,
-      resolveWithFullResponse: true,
-      encoding: null,
-      headers: {
-        'Authorization': 'Bearer ' + createToken('GET', path, this.apiKeyId, this.serviceId),
-        'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version,
-        "Content-type": "application/pdf"
-      }
-    };
+    _.extend(options, additionalOptions)
     if(this.proxy !== null) options.proxy = this.proxy;
 
     return restClient(options);

--- a/client/api_client.js
+++ b/client/api_client.js
@@ -87,7 +87,7 @@ _.extend(ApiClient.prototype, {
       uri: this.urlBase + path,
       json: true,
       resolveWithFullResponse: true,
-      encoding: "base64",
+      encoding: null,
       headers: {
         'Authorization': 'Bearer ' + createToken('GET', path, this.apiKeyId, this.serviceId),
         'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version,

--- a/client/api_client.js
+++ b/client/api_client.js
@@ -81,6 +81,24 @@ _.extend(ApiClient.prototype, {
     return restClient(options);
   },
 
+  getPdf: function(path) {
+    var options = {
+      method: 'GET',
+      uri: this.urlBase + path,
+      json: true,
+      resolveWithFullResponse: true,
+      encoding: "base64",
+      headers: {
+        'Authorization': 'Bearer ' + createToken('GET', path, this.apiKeyId, this.serviceId),
+        'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version,
+        "Content-type": "application/pdf"
+      }
+    };
+    if(this.proxy !== null) options.proxy = this.proxy;
+
+    return restClient(options);
+  },
+
   /**
    *
    * @param {string} path

--- a/client/notification.js
+++ b/client/notification.js
@@ -236,6 +236,23 @@ _.extend(NotifyClient.prototype, {
 
   /**
    *
+   * @param {String} notificationId
+   *
+   * @returns {Promise}
+   */
+  getPdfForLetterNotification: function(notificationId) {
+    const url = '/v2/notifications/' + notificationId + '/pdf'
+
+    return this.apiClient.getPdf(url)
+    .then(function(response) {
+      var encoded_pdf = JSON.parse(Buffer.from(response.body, "base64").toString("utf8")).content
+      var pdf = Buffer.from(encoded_pdf, "base64")
+      return pdf
+    });
+  },
+
+  /**
+   *
    * @param {String} templateId
    *
    * @returns {Promise}

--- a/client/notification.js
+++ b/client/notification.js
@@ -245,8 +245,7 @@ _.extend(NotifyClient.prototype, {
 
     return this.apiClient.getPdf(url)
     .then(function(response) {
-      var encoded_pdf = JSON.parse(Buffer.from(response.body, "base64").toString("utf8")).content
-      var pdf = Buffer.from(encoded_pdf, "base64")
+      var pdf = Buffer.from(response.body, "base64")
       return pdf
     });
   },

--- a/client/notification.js
+++ b/client/notification.js
@@ -243,7 +243,7 @@ _.extend(NotifyClient.prototype, {
   getPdfForLetterNotification: function(notificationId) {
     const url = '/v2/notifications/' + notificationId + '/pdf'
 
-    return this.apiClient.getPdf(url)
+    return this.apiClient.get(url, { encoding: null })
     .then(function(response) {
       var pdf = Buffer.from(response.body, "base64")
       return pdf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
     "chai-json-schema": "1.5.0",
+    "chai-bytes": "0.1.2",
     "jsonschema": "1.2.4",
     "mocha": "5.2.0",
     "mockdate": "2.0.2",

--- a/spec/integration/schemas/v2/POST_notification_precompiled_letter_response.json
+++ b/spec/integration/schemas/v2/POST_notification_precompiled_letter_response.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "description": "POST notification precompiled letter response schema",
+    "type" : "object",
+    "properties": {
+        "id": {"$ref": "definitions.json#/uuid"},
+        "reference": {"type": ["string", "null"]},
+        "postage": {"type": "string"},
+        "content": {"$ref": "definitions.json#/letter_content"},
+        "uri": {"type": "string"},
+        "template": {"$ref": "definitions.json#/template"},
+        "scheduled_for": {"oneOf":[
+          {"$ref": "definitions.json#/datetime"},
+          {"type": "null"}
+        ]}
+    },
+    "additionalProperties": false,
+    "required": ["id", "postage"]
+  }

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -198,14 +198,6 @@ describer('notification api with a live service', function () {
       should.exist(letterNotificationId)
       pdf_contents = fs.readFileSync('./spec/integration/test_files/one_page_pdf.pdf');
       var count = 0
-      // make sure test is closed
-      const endTest = (err) => {
-        if (err !== undefined) {
-          done(err);
-        } else {
-          done();
-        }
-      };
       // it takes a while for the pdf for a freshly sent letter to become ready, so we need to retry the promise
       // a few times, and apply delay in between the attempts. Since our function returns a promise,
       // and it's asynchronous, we cannot use a regular loop to do that. That's why we envelop our promise in a
@@ -213,20 +205,19 @@ describer('notification api with a live service', function () {
       const tryClient = () => {
         return notifyClient.getPdfForLetterNotification(letterNotificationId)
         .then((file_buffer) => {
-          var fileBuffer = file_buffer
           expect(pdf_contents).to.equalBytes(file_buffer);
-          endTest();
+          done();
         })
         .catch((err) => {
           if (err.constructor.name === 'AssertionError') {
-            endTest(err)
+            done(err);
           }
           if (err.error && (err.error.errors[0].error === "PDFNotReadyError")) {
             count += 1
             if (count < 7) {
               setTimeout(tryClient, 5000)
             } else {
-              endTest(new Error('Too many PDFNotReadyError errors'));
+              done(new Error('Too many PDFNotReadyError errors'));
             }
           };
         })

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -1,3 +1,7 @@
+const chai = require('chai');
+const chaiBytes = require('chai-bytes');
+chai.use(chaiBytes);
+
 let expect = require('chai').expect,
   NotifyClient = require('../client/notification.js').NotifyClient,
   MockDate = require('mockdate'),
@@ -252,6 +256,21 @@ describe('notification api', () => {
     return notifyClient.getNotificationById(notificationId)
       .then(function (response) {
         expect(response.statusCode).to.equal(200);
+      });
+  });
+
+  it('should get letter pdf by id', () => {
+
+    let pdf_file = Buffer.from("%PDF-1.5 testpdf")
+    let notificationId = 'wfdfdgf';
+
+    notifyAuthNock
+      .get('/v2/notifications/' + notificationId + '/pdf')
+      .reply(200, {content: pdf_file.toString('base64')});
+
+    return notifyClient.getPdfForLetterNotification(notificationId)
+      .then(function (response_buffer) {
+        expect(response_buffer).to.equalBytes(pdf_file)
       });
   });
 

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -266,7 +266,7 @@ describe('notification api', () => {
 
     notifyAuthNock
       .get('/v2/notifications/' + notificationId + '/pdf')
-      .reply(200, {content: pdf_file.toString('base64')});
+      .reply(200, pdf_file.toString());
 
     return notifyClient.getPdfForLetterNotification(notificationId)
       .then(function (response_buffer) {


### PR DESCRIPTION
Let our users get a pdf for a letter that they have sent.
It's the same feature like this PR, just in Node: https://github.com/alphagov/notifications-python-client/pull/144/files

Also fix an error in functional test for sending a precompiled letter.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [x] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
