### PR TITLE
Consistent context for email_reply_to_id and smsSenderId across our client documentation (Node)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -240,7 +240,7 @@ To add a reply-to email address:
 emailReplyToId='8e222534-7f05-4972-86e3-17c5d9f894e2'
 ```
 
-If you do not have an `emailReplyToId`, you can leave out this argument.
+You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.
 
 ### Response
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -118,7 +118,7 @@ In this screen, you can either:
   - copy the sender ID that you want to use and paste it into the method
   - select __Change__ to change the default sender that the service will use, and select __Save__
 
-If you do not have an `smsSenderId`, you can leave out this argument.
+You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.
 
 ### Response
 


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
When mentioning the optional argument `email_reply_to_id` It should say across all clients:

> You can leave out this argument if your service only has one reply-to email address, or you want to use the default email address.

Similarly, for `smsSenderId`, all clients should use:

> You can leave out this argument if your service only has one text message sender, or if you want to use the default sender.

Pivotal story: https://www.pivotaltracker.com/story/show/170575582

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
