### PR TITLE
Update Node to latest long-term-supported version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3-slim
+FROM node:12.16.1-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		make \
+		gnupg \
 	&& echo "Clean up" \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
We think we may have some sub-dependencies which aren’t working with this older version of Node. Let’s try bringing it up to date to see if that resolves things.