### PR TITLE
BAU Remove __dirname global call from api client

### DIFF
--- a/client/api_client.js
+++ b/client/api_client.js
@@ -2,7 +2,7 @@ var restClient = require('request-promise'),
     _ = require('underscore'),
     createGovukNotifyToken = require('../client/authentication.js'),
     notifyProductionAPI = 'https://api.notifications.service.gov.uk'
-    version = require(__dirname + '/../package.json').version;
+    version = require('../package.json').version;
 
 /**
  * @param urlBase

--- a/spec/api_client.js
+++ b/spec/api_client.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect,
   ApiClient = require('../client/api_client.js'),
   nock = require('nock'),
   createGovukNotifyToken = require('../client/authentication.js'),
-  version = require(__dirname + '/../package.json').version;
+  version = require('../package.json').version;
 
 
 describe('api client', function () {


### PR DESCRIPTION
`__dirname` is a global value made available to Node at runtime. This
will provide the directory where the exucuting file is located. As the
client files are static and always run from the same context, relying on
`__dirname` should not be required here.

Removing this path concatination would also resolve a corner case if the
library is being built by a code bundler that replaces the global value
of `__dirname` (this is an edge case and not default behaviour however may be
set by some configurations).

If the files are being bundled, directly referencing the relative
package JSON independent of the `__dirname` value will allow the bundler
to include this file.

More information on why this global may be overriden by a bundler can be
found here https://webpack.js.org/configuration/node/#node__dirname.