### PR TITLE
BAU: remove __dirname global call from api client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.7.3] - 2020-04-03
+
+### Changed
+
+* Remove `__dirname` global call from api client
+
 ## [4.7.2] - 2020-01-31
 
 ### Changed

--- a/client/api_client.js
+++ b/client/api_client.js
@@ -2,7 +2,7 @@ var restClient = require('request-promise'),
     _ = require('underscore'),
     createGovukNotifyToken = require('../client/authentication.js'),
     notifyProductionAPI = 'https://api.notifications.service.gov.uk'
-    version = require(__dirname + '/../package.json').version;
+    version = require('../package.json').version;
 
 /**
  * @param urlBase

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "description": "GOV.UK Notify Node.js client ",
   "main": "index.js",

--- a/spec/api_client.js
+++ b/spec/api_client.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect,
   ApiClient = require('../client/api_client.js'),
   nock = require('nock'),
   createGovukNotifyToken = require('../client/authentication.js'),
-  version = require(__dirname + '/../package.json').version;
+  version = require('../package.json').version;
 
 
 describe('api client', function () {


### PR DESCRIPTION
This is a rebased version of https://github.com/alphagov/notifications-node-client/pull/113 which includes a version bump and changelog entry. Set up in a new branch so it can run against our CI system as the original PR was from an external contributor.

`__dirname` is a global value made available to Node at runtime. This
will provide the directory where the exucuting file is located. As the
client files are static and always run from the same context, relying on
`__dirname` should not be required here.

Removing this path concatination would also resolve a corner case if the
library is being built by a code bundler that replaces the global value
of `__dirname` (this is an edge case and not default behaviour however may be
set by some configurations).

If the files are being bundled, directly referencing the relative
package JSON independent of the `__dirname` value will allow the bundler
to include this file.

More information on why this global may be overriden by a bundler can be
found here https://webpack.js.org/configuration/node/#node__dirname.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
