### PR TITLE
Add isCsv argument to prepareUpload function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.8.0
+
+### Changed
+
+* Add support for an optional `isCsv` parameter in the `prepareUpload` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.
+
 ## [4.7.3] - 2020-04-03
 
 ### Changed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -326,6 +326,25 @@ The method returns a [promise](https://developer.mozilla.org/en-US/docs/Web/Java
 - resolve with a `response` if successful
 - fail with an `err` if unsuccessful
 
+#### CSV Files
+
+Uploads for CSV files should use the `isCsv` parameter on the `prepareUpload()` function.  For example:
+
+```javascript
+var fs = require('fs')
+
+fs.readFile('path/to/document.csv', function (err, csvFile) {
+  console.log(err)
+  notifyClient.sendEmail(templateId, emailAddress, {
+    personalisation: {
+      first_name: 'Amala',
+      application_date: '2018-01-01',
+      link_to_file: notifyClient.prepareUpload(csvFile, true)
+    }
+  }).then(response => console.log(response.body)).catch(err => console.error(err))
+})
+```
+
 ### Response
 
 If the request to the client is successful, the promise resolves with an `object`:

--- a/client/notification.js
+++ b/client/notification.js
@@ -329,8 +329,18 @@ _.extend(NotifyClient.prototype, {
     this.apiClient.setProxy(url);
   },
 
-  prepareUpload: function(pdf_data) {
-    return {'file': _check_and_encode_file(pdf_data, 2)}
+  /**
+  *
+  * @param {Buffer} pdf_data
+  * @param {Boolean} isCsv
+  *
+  * @returns {Dictionary}
+  */
+  prepareUpload: function(pdf_data, isCsv = false) {
+    return {
+      'file': _check_and_encode_file(pdf_data, 2),
+      'is_csv': isCsv
+    }
   },
 
 });

--- a/client/notification.js
+++ b/client/notification.js
@@ -331,14 +331,14 @@ _.extend(NotifyClient.prototype, {
 
   /**
   *
-  * @param {Buffer} pdf_data
+  * @param {Buffer} fileData
   * @param {Boolean} isCsv
   *
   * @returns {Dictionary}
   */
-  prepareUpload: function(pdf_data, isCsv = false) {
+  prepareUpload: function(fileData, isCsv = false) {
     return {
-      'file': _check_and_encode_file(pdf_data, 2),
+      'file': _check_and_encode_file(fileData, 2),
       'is_csv': isCsv
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.7.3",
+  "version": "4.8.0",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "repository": {
     "type": "git",

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -109,6 +109,22 @@ describer('notification api with a live service', function () {
       })
     });
 
+    it('send email notification with CSV document upload', () => {
+      var postEmailNotificationResponseJson = require('./schemas/v2/POST_notification_email_response.json'),
+        options = {personalisation: { name: 'Foo', documents:
+          notifyClient.prepareUpload(Buffer.from("a,b"), true)
+        }, reference: clientRef};
+
+      return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
+        response.statusCode.should.equal(201);
+        expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
+        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
+        response.body.content.subject.should.equal('Functional Tests are good');
+        response.body.reference.should.equal(clientRef);
+        emailNotificationId = response.body.id;
+      })
+    });
+
     it('send sms notification', () => {
       var postSmsNotificationResponseJson = require('./schemas/v2/POST_notification_sms_response.json'),
         options = {personalisation: personalisation};

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -113,6 +113,57 @@ describe('notification api', () => {
       return notifyClient.sendEmail(templateId, email, options)
       .then((response) => {
         expect(response.statusCode).to.equal(200);
+        expect(response.request.body).to.include('"is_csv":false');
+      });
+    });
+
+    it('should send an email with CSV document upload', () => {
+      let email = 'dom@example.com',
+        templateId = '123',
+        options = {
+          personalisation: {documents:
+            notifyClient.prepareUpload(Buffer.from("a,b"), true)
+          },
+        },
+        data = {
+          template_id: templateId,
+          email_address: email,
+          personalisation: options.personalisation,
+        };
+
+      notifyAuthNock
+      .post('/v2/notifications/email', data)
+      .reply(200, {hooray: 'bkbbk'});
+
+      return notifyClient.sendEmail(templateId, email, options)
+      .then((response) => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.request.body).to.include('"is_csv":true');
+      });
+    });
+
+    it('should send an email with non CSV document upload', () => {
+      let email = 'dom@example.com',
+        templateId = '123',
+        options = {
+          personalisation: {documents:
+            notifyClient.prepareUpload(Buffer.from("%PDF-1.5 testpdf"), false)
+          },
+        },
+        data = {
+          template_id: templateId,
+          email_address: email,
+          personalisation: options.personalisation,
+        };
+
+      notifyAuthNock
+      .post('/v2/notifications/email', data)
+      .reply(200, {hooray: 'bkbbk'});
+
+      return notifyClient.sendEmail(templateId, email, options)
+      .then((response) => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.request.body).to.include('"is_csv":false');
       });
     });
 


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
This will allow node client to ensure CSV files they upload are
downloaded as .csv files rather than .txt files.

This should be analagous to alphagov/notifications-python-client#165

## Checklist
<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
