### PR TITLE
Rename whitelist to guest list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ export SMS_TEMPLATE_ID="valid sms_template_id"
 export LETTER_TEMPLATE_ID="valid letter_template_id"
 export EMAIL_REPLY_TO_ID="valid email reply to id"
 export SMS_SENDER_ID="valid sms_sender_id - to test sending to a receiving number, so needs to be a valid number"
-export API_SENDING_KEY="API_whitelist_key for sending a SMS to a receiving number"
+export API_SENDING_KEY="API_team_key for sending a SMS to a receiving number"
 export INBOUND_SMS_QUERY_KEY="API_test_key to get received text messages - leave blank for local development as cannot test locally"
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -143,7 +143,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If you are using the [test API key](#test), all your messages come back with a `delivered` status.
 
-All messages sent using the [team and whitelist](#team-and-whitelist) or [live](#live) keys appear on your dashboard.
+All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys appear on your dashboard.
 
 ### Error codes
 

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -30,7 +30,7 @@ describer('notification api with a live service', function () {
   this.timeout(40000)
 
   let notifyClient;
-  let whitelistNotifyClient;
+  let teamNotifyClient;
   let emailNotificationId;
   let smsNotificationId;
   let letterNotificationId;
@@ -54,9 +54,9 @@ describer('notification api with a live service', function () {
     const urlBase = process.env.NOTIFY_API_URL;
     const apiKeyId = process.env.API_KEY
     const inboundSmsKeyId = process.env.INBOUND_SMS_QUERY_KEY;
-    const whitelistApiKeyId = process.env.API_SENDING_KEY;
+    const teamApiKeyId = process.env.API_SENDING_KEY;
     notifyClient = new NotifyClient(urlBase, apiKeyId);
-    whitelistNotifyClient = new NotifyClient(urlBase, whitelistApiKeyId);
+    teamNotifyClient = new NotifyClient(urlBase, teamApiKeyId);
     receivedTextClient = new NotifyClient(urlBase, inboundSmsKeyId);
     var definitions_json = require('./schemas/v2/definitions.json');
     chai.tv4.addSchema('definitions.json', definitions_json);
@@ -126,7 +126,7 @@ describer('notification api with a live service', function () {
         options = {personalisation: personalisation, reference: clientRef, smsSenderId: smsSenderId};
 
       should.exist(smsSenderId);
-      return whitelistNotifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
+      return teamNotifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
         response.statusCode.should.equal(201);
         expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
         response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');


### PR DESCRIPTION
We’re renaming the ‘Team and whitelist’ key in https://github.com/alphagov/notifications-admin/pull/3479

This commit updates the documentation to match.
