### PR TITLE
Add letter_contact_block to the template responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 4.8.0
+## 4.9.0 - 2020-08-19
+
+### Changed
+
+* Added `letter_contact_block` to the responses for `getTemplateById`, `getTemplateByIdAndVersion` and `getAllTemplates`.
+
+## 4.8.0 - 2020-06-18
 
 ### Changed
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -903,7 +903,8 @@ If the request to the client is successful, the promise resolves with an `object
   'version': 'version',
   'created_by': 'someone@example.com',
   'body': 'body',
-  'subject': 'null|email_subject'
+  'subject': 'null|email_subject',
+  'letter_contact_block': 'null|letter_contact_block'
 }
 ```
 
@@ -962,7 +963,8 @@ If the request to the client is successful, the promise resolves with an `object
   'version': 'version',
   'created_by': 'someone@example.com',
   'body': 'body',
-  'subject': 'null|email_subject'
+  'subject': 'null|email_subject',
+  'letter_contact_block': 'null|letter_contact_block'
 }
 ```
 
@@ -1022,7 +1024,8 @@ If the request to the client is successful, the promise resolves with an `object
       'version': 'version',
       'created_by': 'someone@example.com',
       'body': 'body',
-      'subject': 'null|email_subject'
+      'subject': 'null|email_subject',
+      'letter_contact_block': 'null|letter_contact_block'
     },
     {
       // … another template

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "repository": {
     "type": "git",

--- a/spec/integration/schemas/v2/GET_template_by_id.json
+++ b/spec/integration/schemas/v2/GET_template_by_id.json
@@ -20,7 +20,11 @@
         "created_by": {"type": "string"},
         "version": {"type": "integer"},
         "body": {"type": "string"},
-        "subject": {"type": ["string", "null"]}
+        "subject": {"type": ["string", "null"]},
+        "letter_contact_block": {"type": ["string", "null"]}
     },
-    "required": ["id", "name", "type", "created_at", "updated_at", "version", "created_by", "body"]
+    "required": [
+        "id", "name", "type", "created_at", "updated_at", "version", "created_by",
+        "body", "letter_contact_block"
+    ]
 }

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -266,6 +266,7 @@ describer('notification api with a live service', function () {
         expect(response.body).to.be.jsonSchema(getTemplateJson);
         response.body.name.should.equal('Client Functional test sms template');
         should.not.exist(response.body.subject);
+        should.not.exist(response.body.letter_contact_block);
       });
     });
 
@@ -276,6 +277,7 @@ describer('notification api with a live service', function () {
         response.body.body.should.equal('Hello ((name))\r\n\r\nFunctional test help make our world a better place');
         response.body.name.should.equal('Client Functional test email template');
         response.body.subject.should.equal('Functional Tests are good');
+        should.not.exist(response.body.letter_contact_block);
       });
     });
 
@@ -286,6 +288,10 @@ describer('notification api with a live service', function () {
         response.body.body.should.equal('Hello ((address_line_1))');
         response.body.name.should.equal('Client functional letter template');
         response.body.subject.should.equal('Main heading');
+        response.body.letter_contact_block.should.equal(
+          'Government Digital Service\nThe White Chapel Building\n' +
+          '10 Whitechapel High Street\nLondon\nE1 8QS\nUnited Kingdom'
+        );
       });
     });
 
@@ -296,6 +302,7 @@ describer('notification api with a live service', function () {
         response.body.name.should.equal('Example text message template');
         should.not.exist(response.body.subject);
         response.body.version.should.equal(1);
+        should.not.exist(response.body.letter_contact_block);
       });
     });
 
@@ -314,6 +321,8 @@ describer('notification api with a live service', function () {
         expect(response.body).to.be.jsonSchema(getTemplateJson);
         response.body.name.should.equal('Untitled');
         response.body.version.should.equal(1);
+        // version 1 of the template had no letter_contact_block
+        should.not.exist(response.body.letter_contact_block);
       });
     });
 


### PR DESCRIPTION
When notifications-api returns a template it now includes the `letter_contact_block` in the data. This field is automatically returned for the `getTemplateById`, `getTemplateByIdAndVersion` and `getAllTemplates` functions. This change adds the documentation and tests for it and bumps the version of the client.