### PR TITLE
Move from `request-promise` to `axios`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ We have replaced the use of the npm [request-promise](https://www.npmjs.com/pack
     notifyClient.setProxy({ host: "exampleproxy.com", port: 2345 })
     ```
 
-4. We now return native [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) rather than [bluebird promises](http://bluebirdjs.com). It is unlikely you will need to make any changes unless you are using some of the additional methods found on bluebird promises that do not exist on native promises.
+4. We now return native [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) rather than [bluebird promises](http://bluebirdjs.com). You will not need to make any changes unless you are using some of the additional methods found on bluebird promises that do not exist on native promises.
 
 
 ## 4.9.0 - 2020-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 5.0.0 - 2020-09-02
+
+### Changed
+
+We have replaced the use of the npm [request-promise](https://www.npmjs.com/package/request-promise) package with [axios](https://www.npmjs.com/package/axios) as the npm `request` package has been deprecated. This makes the following breaking changes.
+
+1. The `object` returned by an API call is now of the form of an [axios response](https://www.npmjs.com/package/axios#response-schema) which has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_serverresponse), of particular note
+
+    * `response.body` becomes `response.data`
+    * `response.status_code` becomes `response.status`
+
+2. To configure the use of a proxy you should pass the proxy configuration as an object as per [axios](https://github.com/axios/axios) rather than a URL.
+
+    Before:
+
+    ```
+    notifyClient.setProxy("exampleproxy.com:2345")
+    ```
+
+    After:
+
+    ```
+    notifyClient.setProxy({ host: "exampleproxy.com", port: 2345 })
+    ```
+
+3. We now return native [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) rather than [bluebird promises](http://bluebirdjs.com). It is unlikely you will need to make any changes unless you are using some of the additional methods found on bluebird promises that do not exist on native promises.
+
+
 ## 4.9.0 - 2020-08-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,16 @@
 
 ### Changed
 
-We have replaced the use of the npm [request-promise](https://www.npmjs.com/package/request-promise) package with [axios](https://www.npmjs.com/package/axios) as the npm `request` package has been deprecated. This makes the following breaking changes:
+We have replaced the use of the npm [request-promise](https://www.npmjs.com/package/request-promise) package with [axios](https://www.npmjs.com/package/axios) as the npm [request](https://www.npmjs.com/package/request) package has been deprecated. This makes the following breaking changes:
 
-1. The `response` `object` returned by a successful API call is now of the form of an [axios response](https://www.npmjs.com/package/axios#response-schema) which has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_incomingmessage), of particular note
+1. The `response` `object` returned by a successful API call is now in the form of an [axios response](https://www.npmjs.com/package/axios#response-schema). This has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_incomingmessage). For example:
 
     * `response.body` becomes `response.data`
     * `response.statusCode` becomes `response.status`
 
-2. The `err` `object` returned by an unsuccessful API call has a different interface, of particular note
+2. The `err` `object` returned by an unsuccessful API call has a different interface. For example, `err.error` becomes `err.response.data`. See the axios documentation for further details on [error handling](https://www.npmjs.com/package/axios#handling-errors).
 
-    * `err.error` becomes `err.response.data`
-
-    See the axios documentation for further details on [error handling](https://www.npmjs.com/package/axios#handling-errors).
-
-3. To configure the use of a proxy you should pass the proxy configuration as an object as per [axios](https://github.com/axios/axios) rather than a URL.
-
-    Before:
-
-    ```
-    notifyClient.setProxy("exampleproxy.com:2345")
-    ```
-
-    After:
-
-    ```
-    notifyClient.setProxy({ host: "exampleproxy.com", port: 2345 })
-    ```
+3. To configure the use of a proxy you should pass the proxy configuration as an `object` rather than a URL. For details, see the [axios client](https://github.com/axios/axios).
 
 4. We now return native [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) rather than [bluebird promises](http://bluebirdjs.com). You will not need to make any changes unless you are using some of the additional methods found on bluebird promises that do not exist on native promises.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changed
 
-We have replaced the use of the npm [request-promise](https://www.npmjs.com/package/request-promise) package with [axios](https://www.npmjs.com/package/axios) as the npm `request` package has been deprecated. This makes the following breaking changes.
+We have replaced the use of the npm [request-promise](https://www.npmjs.com/package/request-promise) package with [axios](https://www.npmjs.com/package/axios) as the npm `request` package has been deprecated. This makes the following breaking changes:
 
 1. The `response` `object` returned by a successful API call is now of the form of an [axios response](https://www.npmjs.com/package/axios#response-schema) which has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_incomingmessage), of particular note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 We have replaced the use of the npm [request-promise](https://www.npmjs.com/package/request-promise) package with [axios](https://www.npmjs.com/package/axios) as the npm `request` package has been deprecated. This makes the following breaking changes.
 
-1. The `object` returned by an API call is now of the form of an [axios response](https://www.npmjs.com/package/axios#response-schema) which has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_serverresponse), of particular note
+1. The `object` returned by an API call is now of the form of an [axios response](https://www.npmjs.com/package/axios#response-schema) which has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_incomingmessage), of particular note
 
     * `response.body` becomes `response.data`
-    * `response.status_code` becomes `response.status`
+    * `response.statusCode` becomes `response.status`
 
 2. To configure the use of a proxy you should pass the proxy configuration as an object as per [axios](https://github.com/axios/axios) rather than a URL.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 We have replaced the use of the npm [request-promise](https://www.npmjs.com/package/request-promise) package with [axios](https://www.npmjs.com/package/axios) as the npm `request` package has been deprecated. This makes the following breaking changes.
 
-1. The `object` returned by an API call is now of the form of an [axios response](https://www.npmjs.com/package/axios#response-schema) which has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_incomingmessage), of particular note
+1. The `response` `object` returned by a successful API call is now of the form of an [axios response](https://www.npmjs.com/package/axios#response-schema) which has a different interface to a [request response](https://nodejs.org/api/http.html#http_class_http_incomingmessage), of particular note
 
     * `response.body` becomes `response.data`
     * `response.statusCode` becomes `response.status`
 
-2. To configure the use of a proxy you should pass the proxy configuration as an object as per [axios](https://github.com/axios/axios) rather than a URL.
+2. The `err` `object` returned by an unsuccessful API call has a different interface, of particular note
+
+    * `err.error` becomes `err.response.data`
+
+    See the axios documentation for further details on [error handling](https://www.npmjs.com/package/axios#handling-errors).
+
+3. To configure the use of a proxy you should pass the proxy configuration as an object as per [axios](https://github.com/axios/axios) rather than a URL.
 
     Before:
 
@@ -23,7 +29,7 @@ We have replaced the use of the npm [request-promise](https://www.npmjs.com/pack
     notifyClient.setProxy({ host: "exampleproxy.com", port: 2345 })
     ```
 
-3. We now return native [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) rather than [bluebird promises](http://bluebirdjs.com). It is unlikely you will need to make any changes unless you are using some of the additional methods found on bluebird promises that do not exist on native promises.
+4. We now return native [promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises) rather than [bluebird promises](http://bluebirdjs.com). It is unlikely you will need to make any changes unless you are using some of the additional methods found on bluebird promises that do not exist on native promises.
 
 
 ## 4.9.0 - 2020-08-19

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -129,7 +129,7 @@ You can leave out this argument if your service only has one text message sender
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -251,7 +251,7 @@ You can leave out this argument if your service only has one reply-to email addr
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -354,7 +354,7 @@ fs.readFile('path/to/document.csv', function (err, csvFile) {
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -481,7 +481,7 @@ A unique identifier you can create if required. This reference identifies a sing
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -564,7 +564,7 @@ You can choose first or second class postage for your precompiled letter. Set th
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -660,7 +660,7 @@ You can also find it by [signing in to GOV.UK Notify](https://www.notifications.
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -770,7 +770,7 @@ If you pass in an empty argument or `null`, the client returns the most recent 2
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -898,7 +898,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -958,7 +958,7 @@ The version number of the template.
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -1017,7 +1017,7 @@ If you do not use `templateType`, the client returns all templates. Otherwise yo
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {
@@ -1091,7 +1091,7 @@ You can leave out this argument if a template does not have any placeholder fiel
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like this:
 
 ```javascript
 {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -129,7 +129,7 @@ You can leave out this argument if your service only has one text message sender
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -251,7 +251,7 @@ You can leave out this argument if your service only has one reply-to email addr
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -354,7 +354,7 @@ fs.readFile('path/to/document.csv', function (err, csvFile) {
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -481,7 +481,7 @@ A unique identifier you can create if required. This reference identifies a sing
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -564,7 +564,7 @@ You can choose first or second class postage for your precompiled letter. Set th
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -660,7 +660,7 @@ You can also find it by [signing in to GOV.UK Notify](https://www.notifications.
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -770,7 +770,7 @@ If you pass in an empty argument or `null`, the client returns the most recent 2
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -898,7 +898,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -958,7 +958,7 @@ The version number of the template.
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -1017,7 +1017,7 @@ If you do not use `templateType`, the client returns all templates. Otherwise yo
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {
@@ -1091,7 +1091,7 @@ You can leave out this argument if a template does not have any placeholder fiel
 
 ### Response
 
-If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
+If the request is successful, the promise resolves with a `response` `object`. For example, the `response.data` property will look like:
 
 ```javascript
 {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -29,8 +29,15 @@ To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.
 Add this code to your application:
 
 ```javascript
-notifyClient.setProxy(proxyUrl)
+proxyConfig = {
+  host: proxyHost,
+  port: proxyPort
+}
+
+notifyClient.setProxy(proxyConfig)
 ```
+
+where the `proxyConfig` should be an object supported by [axios](https://github.com/axios/axios).
 
 # Send a message
 
@@ -149,7 +156,7 @@ All messages sent using the [team and guest list](#team-and-guest-list) or [live
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -268,7 +275,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:--- |:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -317,7 +324,7 @@ fs.readFile('path/to/document.pdf', function (err, pdfFile) {
       application_date: '2018-01-01',
       link_to_file: notifyClient.prepareUpload(pdfFile)
     }
-  }).then(response => console.log(response.body)).catch(err => console.error(err))
+  }).then(response => console.log(response)).catch(err => console.error(err))
 })
 ```
 
@@ -341,7 +348,7 @@ fs.readFile('path/to/document.csv', function (err, csvFile) {
       application_date: '2018-01-01',
       link_to_file: notifyClient.prepareUpload(csvFile, true)
     }
-  }).then(response => console.log(response.body)).catch(err => console.error(err))
+  }).then(response => console.log(response)).catch(err => console.error(err))
 })
 ```
 
@@ -371,7 +378,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -498,7 +505,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:--- |:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -571,7 +578,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:--- |:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
@@ -688,7 +695,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
@@ -805,7 +812,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "bad status is not one of [created, sending, sent, delivered, pending, failed, technical-failure, temporary-failure, permanent-failure, accepted, received]"`<br>`}]`|Contact the GOV.UK Notify team|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Applet is not one of [sms, email, letter]"`<br>`}]`|Contact the GOV.UK Notify team|
@@ -912,7 +919,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
@@ -972,7 +979,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
@@ -1101,7 +1108,7 @@ If the request to the client is successful, the promise resolves with an `object
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Missing personalisation: [PERSONALISATION FIELD]"`<br>`}]`|Check that the personalisation arguments in the method match the placeholder fields in the template|
 |`400`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the [template ID](#generate-a-preview-template-required-arguments-template-id)|
@@ -1184,7 +1191,7 @@ If the notification specified in the `olderThan` argument is older than 7 days, 
 
 If the request is not successful, the promise fails with an `err`.
 
-|err.error.status_code|err.error.errors|How to fix|
+|err.response.data.status_code|err.response.data.errors|How to fix|
 |:---|:---|:---|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -129,7 +129,7 @@ You can leave out this argument if your service only has one text message sender
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -251,7 +251,7 @@ You can leave out this argument if your service only has one reply-to email addr
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -354,7 +354,7 @@ fs.readFile('path/to/document.csv', function (err, csvFile) {
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -481,7 +481,7 @@ A unique identifier you can create if required. This reference identifies a sing
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -564,7 +564,7 @@ You can choose first or second class postage for your precompiled letter. Set th
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -660,7 +660,7 @@ You can also find it by [signing in to GOV.UK Notify](https://www.notifications.
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -770,7 +770,7 @@ If you pass in an empty argument or `null`, the client returns the most recent 2
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -898,7 +898,7 @@ The ID of the template. [Sign in to GOV.UK Notify](https://www.notifications.ser
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -958,7 +958,7 @@ The version number of the template.
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -1017,7 +1017,7 @@ If you do not use `templateType`, the client returns all templates. Otherwise yo
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {
@@ -1091,7 +1091,7 @@ You can leave out this argument if a template does not have any placeholder fiel
 
 ### Response
 
-If the request to the client is successful, the promise resolves with an `object`:
+If the request is successful, the promise resolves with a `response` `object`, such that `response.data` is:
 
 ```javascript
 {

--- a/client/api_client.js
+++ b/client/api_client.js
@@ -1,4 +1,4 @@
-var restClient = require('request-promise'),
+var restClient = require('axios').default,
     _ = require('underscore'),
     createGovukNotifyToken = require('../client/authentication.js'),
     notifyProductionAPI = 'https://api.notifications.service.gov.uk'
@@ -66,13 +66,11 @@ _.extend(ApiClient.prototype, {
    */
   get: function(path, additionalOptions) {
     var options = {
-      method: 'GET',
-      uri: this.urlBase + path,
-      json: true,
-      resolveWithFullResponse: true,
+      method: 'get',
+      url: this.urlBase + path,
       headers: {
         'Authorization': 'Bearer ' + createToken('GET', path, this.apiKeyId, this.serviceId),
-        'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version
+        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
       }
     };
     _.extend(options, additionalOptions)
@@ -90,14 +88,12 @@ _.extend(ApiClient.prototype, {
    */
   post: function(path, data){
     var options = {
-      method: 'POST',
-      uri: this.urlBase + path,
-      json: true,
-      body: data,
-      resolveWithFullResponse: true,
+      method: 'post',
+      url: this.urlBase + path,
+      data: data,
       headers: {
         'Authorization': 'Bearer ' + createToken('GET', path, this.apiKeyId, this.serviceId),
-        'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version
+        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
       }
     };
 
@@ -108,10 +104,10 @@ _.extend(ApiClient.prototype, {
 
   /**
    *
-   * @param {String} url
+   * @param {object} an axios proxy config
    */
-  setProxy: function(url){
-    this.proxy = url;
+  setProxy: function(proxyConfig){
+    this.proxy = proxyConfig
   }
 });
 

--- a/client/notification.js
+++ b/client/notification.js
@@ -244,7 +244,7 @@ _.extend(NotifyClient.prototype, {
     const url = '/v2/notifications/' + notificationId + '/pdf'
 
     // Unlike other requests, we expect a successful response as an arraybuffer and an error as JSON
-    // Axios doesn't support flexible response types so we will need to handle the error case ourselves below
+    // Axios does not support flexible response types so we will need to handle the error case ourselves below
     return this.apiClient.get(url, { responseType: 'arraybuffer' })
     .then(function(response) {
       var pdf = Buffer.from(response.data, "base64")

--- a/client/notification.js
+++ b/client/notification.js
@@ -243,10 +243,23 @@ _.extend(NotifyClient.prototype, {
   getPdfForLetterNotification: function(notificationId) {
     const url = '/v2/notifications/' + notificationId + '/pdf'
 
-    return this.apiClient.get(url, { encoding: null })
+    // Unlike other requests, we expect a successful response as an arraybuffer and an error as JSON
+    // Axios doesn't support flexible response types so we will need to handle the error case ourselves below
+    return this.apiClient.get(url, { responseType: 'arraybuffer' })
     .then(function(response) {
-      var pdf = Buffer.from(response.body, "base64")
+      var pdf = Buffer.from(response.data, "base64")
       return pdf
+    })
+    .catch(function(error) {
+      // If we receive an error, as the response is an arraybuffer rather than our usual JSON
+      // we need to convert it to JSON to be read by the user
+      string_of_error_body = new TextDecoder().decode(error.response.data);
+
+      // Then we replace the error data with the JSON error rather than the arraybuffer of the error
+      error.response.data = JSON.parse(string_of_error_body);
+
+      // and rethrow to let the user handle the error
+      throw error
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "4.9.0",
+  "version": "5.0.0",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "repository": {
     "type": "git",
@@ -17,8 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "jsonwebtoken": "8.2.1",
-    "request": "2.88.0",
-    "request-promise": "4.2.2",
+    "axios": "0.19.2",
     "underscore": "^1.9.0"
   },
   "devDependencies": {

--- a/spec/api_client.js
+++ b/spec/api_client.js
@@ -36,7 +36,7 @@ describe('api client', function () {
       nock(urlBase, {
         reqheaders: {
           'Authorization': 'Bearer ' + createGovukNotifyToken('GET', path, apiKeyId, serviceId),
-          'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version
+          'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
         }
       })
         .get(path)
@@ -44,7 +44,7 @@ describe('api client', function () {
 
       client.get(path)
         .then(function (response) {
-          expect(response.body).to.deep.equal(body);
+          expect(response.data).to.deep.equal(body);
           if (index == clients.length - 1) done();
       });
 
@@ -66,7 +66,7 @@ describe('api client', function () {
     nock(urlBase, {
       reqheaders: {
         'Authorization': 'Bearer ' + createGovukNotifyToken('POST', path, apiKeyId, serviceId),
-        'User-agent': 'NOTIFY-API-NODE-CLIENT/' + version
+        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
       }
     })
       .post(path, data)
@@ -75,45 +75,45 @@ describe('api client', function () {
     apiClient = new ApiClient(urlBase, serviceId, apiKeyId);
     apiClient.post(path, data)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
         done();
     });
   });
 
   it('should direct get requests through the proxy when set', function (done) {
     var urlBase = 'https://api.notifications.service.gov.uk',
-      proxyUrl = 'http://proxy.service.gov.uk:3030/',
+      proxyConfig = { host: 'addressofmyproxy.test'},
       path = '/email',
       apiClient = new ApiClient(urlBase, 'apiKey');
 
-    nock(urlBase)
-      .get(path)
+    nock("http://" + proxyConfig.host)
+      .get(urlBase + path)
       .reply(200, 'test');
 
-    apiClient.setProxy(proxyUrl);
+    apiClient.setProxy(proxyConfig);
     apiClient.get(path)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
-        expect(response.request.proxy.href).to.equal(proxyUrl);
+        expect(response.status).to.equal(200);
+        expect(response.config.proxy).to.eql(proxyConfig);
         done();
     });
   });
 
   it('should direct post requests through the proxy when set', function (done) {
     var urlBase = 'https://api.notifications.service.gov.uk',
-      proxyUrl = 'http://proxy.service.gov.uk:3030/',
+      proxyConfig = { host: 'addressofmyproxy.test'},
       path = '/email',
       apiClient = new ApiClient(urlBase, 'apiKey');
 
-    nock(urlBase)
-      .post(path)
+    nock("http://" + proxyConfig.host)
+      .post(urlBase + path)
       .reply(200, 'test');
 
-    apiClient.setProxy(proxyUrl);
+    apiClient.setProxy(proxyConfig);
     apiClient.post(path)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
-        expect(response.request.proxy.href).to.equal(proxyUrl);
+        expect(response.status).to.equal(200);
+        expect(response.config.proxy).to.eql(proxyConfig);
         done();
     });
   });

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -69,12 +69,12 @@ describer('notification api with a live service', function () {
         options = {personalisation: personalisation, reference: clientRef};
 
       return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
-        response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
-        response.body.content.subject.should.equal('Functional Tests are good');
-        response.body.reference.should.equal(clientRef);
-        emailNotificationId = response.body.id;
+        response.status.should.equal(201);
+        expect(response.data).to.be.jsonSchema(postEmailNotificationResponseJson);
+        response.data.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
+        response.data.content.subject.should.equal('Functional Tests are good');
+        response.data.reference.should.equal(clientRef);
+        emailNotificationId = response.data.id;
       })
     });
 
@@ -84,12 +84,12 @@ describer('notification api with a live service', function () {
 
       should.exist(emailReplyToId);
       return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
-        response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
-        response.body.content.subject.should.equal('Functional Tests are good');
-        response.body.reference.should.equal(clientRef);
-        emailNotificationId = response.body.id;
+        response.status.should.equal(201);
+        expect(response.data).to.be.jsonSchema(postEmailNotificationResponseJson);
+        response.data.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
+        response.data.content.subject.should.equal('Functional Tests are good');
+        response.data.reference.should.equal(clientRef);
+        emailNotificationId = response.data.id;
       })
     });
 
@@ -100,12 +100,12 @@ describer('notification api with a live service', function () {
         }, reference: clientRef};
 
       return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
-        response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
-        response.body.content.subject.should.equal('Functional Tests are good');
-        response.body.reference.should.equal(clientRef);
-        emailNotificationId = response.body.id;
+        response.status.should.equal(201);
+        expect(response.data).to.be.jsonSchema(postEmailNotificationResponseJson);
+        response.data.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
+        response.data.content.subject.should.equal('Functional Tests are good');
+        response.data.reference.should.equal(clientRef);
+        emailNotificationId = response.data.id;
       })
     });
 
@@ -116,12 +116,12 @@ describer('notification api with a live service', function () {
         }, reference: clientRef};
 
       return notifyClient.sendEmail(emailTemplateId, email, options).then((response) => {
-        response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(postEmailNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
-        response.body.content.subject.should.equal('Functional Tests are good');
-        response.body.reference.should.equal(clientRef);
-        emailNotificationId = response.body.id;
+        response.status.should.equal(201);
+        expect(response.data).to.be.jsonSchema(postEmailNotificationResponseJson);
+        response.data.content.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
+        response.data.content.subject.should.equal('Functional Tests are good');
+        response.data.reference.should.equal(clientRef);
+        emailNotificationId = response.data.id;
       })
     });
 
@@ -130,10 +130,10 @@ describer('notification api with a live service', function () {
         options = {personalisation: personalisation};
 
       return notifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
-        response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
-        smsNotificationId = response.body.id;
+        response.status.should.equal(201);
+        expect(response.data).to.be.jsonSchema(postSmsNotificationResponseJson);
+        response.data.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
+        smsNotificationId = response.data.id;
       });
     });
 
@@ -143,10 +143,10 @@ describer('notification api with a live service', function () {
 
       should.exist(smsSenderId);
       return teamNotifyClient.sendSms(smsTemplateId, phoneNumber, options).then((response) => {
-        response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(postSmsNotificationResponseJson);
-        response.body.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
-        smsNotificationId = response.body.id;
+        response.status.should.equal(201);
+        expect(response.data).to.be.jsonSchema(postSmsNotificationResponseJson);
+        response.data.content.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
+        smsNotificationId = response.data.id;
       });
     });
 
@@ -155,10 +155,10 @@ describer('notification api with a live service', function () {
         options = {personalisation: letterContact};
 
       return notifyClient.sendLetter(letterTemplateId, options).then((response) => {
-        response.statusCode.should.equal(201);
-        expect(response.body).to.be.jsonSchema(postLetterNotificationResponseJson);
-        response.body.content.body.should.equal('Hello ' + letterContact.address_line_1);
-        letterNotificationId = response.body.id;
+        response.status.should.equal(201);
+        expect(response.data).to.be.jsonSchema(postLetterNotificationResponseJson);
+        response.data.content.body.should.equal('Hello ' + letterContact.address_line_1);
+        letterNotificationId = response.data.id;
       });
     });
 
@@ -169,9 +169,9 @@ describer('notification api with a live service', function () {
       fs.readFile('./spec/integration/test_files/one_page_pdf.pdf', function(err, pdf_file) {
         return notifyClient.sendPrecompiledLetter("my_reference", pdf_file, "first")
         .then((response) => {
-          response.statusCode.should.equal(201);
-          expect(response.body).to.be.jsonSchema(postPrecompiledLetterNotificationResponseJson);
-          letterNotificationId = response.body.id;
+          response.status.should.equal(201);
+          expect(response.data).to.be.jsonSchema(postPrecompiledLetterNotificationResponseJson);
+          letterNotificationId = response.data.id;
         })
       });
     });
@@ -182,31 +182,31 @@ describer('notification api with a live service', function () {
     it('get email notification by id', () => {
       should.exist(emailNotificationId)
       return notifyClient.getNotificationById(emailNotificationId).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getNotificationJson);
-        response.body.type.should.equal('email');
-        response.body.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
-        response.body.subject.should.equal('Functional Tests are good');
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getNotificationJson);
+        response.data.type.should.equal('email');
+        response.data.body.should.equal('Hello Foo\r\n\r\nFunctional test help make our world a better place');
+        response.data.subject.should.equal('Functional Tests are good');
       });
     });
 
     it('get sms notification by id', () => {
       should.exist(smsNotificationId)
       return notifyClient.getNotificationById(smsNotificationId).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getNotificationJson);
-        response.body.type.should.equal('sms');
-        response.body.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getNotificationJson);
+        response.data.type.should.equal('sms');
+        response.data.body.should.equal('Hello Foo\n\nFunctional Tests make our world a better place');
       });
     });
 
     it('get letter notification by id', () => {
       should.exist(letterNotificationId)
       return notifyClient.getNotificationById(letterNotificationId).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getNotificationJson);
-        response.body.type.should.equal('letter');
-        response.body.body.should.equal('Hello ' + letterContact.address_line_1);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getNotificationJson);
+        response.data.type.should.equal('letter');
+        response.data.body.should.equal('Hello ' + letterContact.address_line_1);
       });
     });
 
@@ -228,7 +228,7 @@ describer('notification api with a live service', function () {
           if (err.constructor.name === 'AssertionError') {
             done(err);
           }
-          if (err.error && (err.error.errors[0].error === "PDFNotReadyError")) {
+          if (err.response.data && (err.response.data.errors[0].error === "PDFNotReadyError")) {
             count += 1
             if (count < 7) {
               setTimeout(tryClient, 5000)
@@ -245,8 +245,8 @@ describer('notification api with a live service', function () {
     it('get all notifications', () => {
       chai.tv4.addSchema('notification.json', getNotificationJson);
       return notifyClient.getNotifications().then((response) => {
-        response.should.have.property('statusCode', 200);
-        expect(response.body).to.be.jsonSchema(getNotificationsJson);
+        response.should.have.property('status', 200);
+        expect(response.data).to.be.jsonSchema(getNotificationsJson);
       });
     });
 
@@ -262,33 +262,33 @@ describer('notification api with a live service', function () {
 
     it('get sms template by id', () => {
       return notifyClient.getTemplateById(smsTemplateId).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplateJson);
-        response.body.name.should.equal('Client Functional test sms template');
-        should.not.exist(response.body.subject);
-        should.not.exist(response.body.letter_contact_block);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplateJson);
+        response.data.name.should.equal('Client Functional test sms template');
+        should.not.exist(response.data.subject);
+        should.not.exist(response.data.letter_contact_block);
       });
     });
 
     it('get email template by id', () => {
       return notifyClient.getTemplateById(emailTemplateId).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplateJson);
-        response.body.body.should.equal('Hello ((name))\r\n\r\nFunctional test help make our world a better place');
-        response.body.name.should.equal('Client Functional test email template');
-        response.body.subject.should.equal('Functional Tests are good');
-        should.not.exist(response.body.letter_contact_block);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplateJson);
+        response.data.body.should.equal('Hello ((name))\r\n\r\nFunctional test help make our world a better place');
+        response.data.name.should.equal('Client Functional test email template');
+        response.data.subject.should.equal('Functional Tests are good');
+        should.not.exist(response.data.letter_contact_block);
       });
     });
 
     it('get letter template by id', () => {
       return notifyClient.getTemplateById(letterTemplateId).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplateJson);
-        response.body.body.should.equal('Hello ((address_line_1))');
-        response.body.name.should.equal('Client functional letter template');
-        response.body.subject.should.equal('Main heading');
-        response.body.letter_contact_block.should.equal(
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplateJson);
+        response.data.body.should.equal('Hello ((address_line_1))');
+        response.data.name.should.equal('Client functional letter template');
+        response.data.subject.should.equal('Main heading');
+        response.data.letter_contact_block.should.equal(
           'Government Digital Service\nThe White Chapel Building\n' +
           '10 Whitechapel High Street\nLondon\nE1 8QS\nUnited Kingdom'
         );
@@ -297,99 +297,99 @@ describer('notification api with a live service', function () {
 
     it('get sms template by id and version', () => {
       return notifyClient.getTemplateByIdAndVersion(smsTemplateId, 1).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplateJson);
-        response.body.name.should.equal('Example text message template');
-        should.not.exist(response.body.subject);
-        response.body.version.should.equal(1);
-        should.not.exist(response.body.letter_contact_block);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplateJson);
+        response.data.name.should.equal('Example text message template');
+        should.not.exist(response.data.subject);
+        response.data.version.should.equal(1);
+        should.not.exist(response.data.letter_contact_block);
       });
     });
 
     it('get email template by id and version', () => {
       return notifyClient.getTemplateByIdAndVersion(emailTemplateId, 1).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplateJson);
-        response.body.name.should.equal('Client Functional test email template');
-        response.body.version.should.equal(1);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplateJson);
+        response.data.name.should.equal('Client Functional test email template');
+        response.data.version.should.equal(1);
       });
     });
 
     it('get letter template by id and version', () => {
       return notifyClient.getTemplateByIdAndVersion(letterTemplateId, 1).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplateJson);
-        response.body.name.should.equal('Untitled');
-        response.body.version.should.equal(1);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplateJson);
+        response.data.name.should.equal('Untitled');
+        response.data.version.should.equal(1);
         // version 1 of the template had no letter_contact_block
-        should.not.exist(response.body.letter_contact_block);
+        should.not.exist(response.data.letter_contact_block);
       });
     });
 
     it('get all templates', () => {
       return notifyClient.getAllTemplates().then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplatesJson);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplatesJson);
       });
     });
 
     it('get sms templates', () => {
       return notifyClient.getAllTemplates('sms').then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplatesJson);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplatesJson);
       });
     });
 
     it('get email templates', () => {
       return notifyClient.getAllTemplates('email').then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplatesJson);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplatesJson);
       });
     });
 
     it('get letter templates', () => {
       return notifyClient.getAllTemplates('letter').then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getTemplatesJson);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getTemplatesJson);
       });
     });
 
     it('preview sms template', () => {
       var personalisation = { "name": "Foo" }
       return notifyClient.previewTemplateById(smsTemplateId, personalisation).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(postTemplatePreviewJson);
-        response.body.type.should.equal('sms');
-        should.not.exist(response.body.subject);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(postTemplatePreviewJson);
+        response.data.type.should.equal('sms');
+        should.not.exist(response.data.subject);
       });
     });
 
     it('preview email template', () => {
       var personalisation = { "name": "Foo" }
       return notifyClient.previewTemplateById(emailTemplateId, personalisation).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(postTemplatePreviewJson);
-        response.body.type.should.equal('email');
-        should.exist(response.body.subject);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(postTemplatePreviewJson);
+        response.data.type.should.equal('email');
+        should.exist(response.data.subject);
       });
     });
 
     it('preview letter template', () => {
       var personalisation = { "address_line_1": "Foo", "address_line_2": "Bar", "postcode": "SW1 1AA" }
       return notifyClient.previewTemplateById(letterTemplateId, personalisation).then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(postTemplatePreviewJson);
-        response.body.type.should.equal('letter');
-        should.exist(response.body.subject);
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(postTemplatePreviewJson);
+        response.data.type.should.equal('letter');
+        should.exist(response.data.subject);
       });
     });
 
     it('get all received texts', () => {
       chai.tv4.addSchema('receivedText.json', getReceivedTextJson);
       return receivedTextClient.getReceivedTexts().then((response) => {
-        response.statusCode.should.equal(200);
-        expect(response.body).to.be.jsonSchema(getReceivedTextsJson);
-        expect(response.body["received_text_messages"]).to.be.an('array').that.is.not.empty;
+        response.status.should.equal(200);
+        expect(response.data).to.be.jsonSchema(getReceivedTextsJson);
+        expect(response.data["received_text_messages"]).to.be.an('array').that.is.not.empty;
       });
     });
 

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -62,7 +62,7 @@ describe('notification api', () => {
 
       return notifyClient.sendEmail(templateId, email, options)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
 
     });
@@ -88,7 +88,7 @@ describe('notification api', () => {
 
       return notifyClient.sendEmail(templateId, email, options)
       .then((response) => {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -112,8 +112,8 @@ describe('notification api', () => {
 
       return notifyClient.sendEmail(templateId, email, options)
       .then((response) => {
-        expect(response.statusCode).to.equal(200);
-        expect(response.request.body).to.include('"is_csv":false');
+        expect(response.status).to.equal(200);
+        expect(response.config.data).to.include('"is_csv":false');
       });
     });
 
@@ -137,8 +137,8 @@ describe('notification api', () => {
 
       return notifyClient.sendEmail(templateId, email, options)
       .then((response) => {
-        expect(response.statusCode).to.equal(200);
-        expect(response.request.body).to.include('"is_csv":true');
+        expect(response.status).to.equal(200);
+        expect(response.config.data).to.include('"is_csv":true');
       });
     });
 
@@ -162,8 +162,8 @@ describe('notification api', () => {
 
       return notifyClient.sendEmail(templateId, email, options)
       .then((response) => {
-        expect(response.statusCode).to.equal(200);
-        expect(response.request.body).to.include('"is_csv":false');
+        expect(response.status).to.equal(200);
+        expect(response.config.data).to.include('"is_csv":false');
       });
     });
 
@@ -211,7 +211,7 @@ describe('notification api', () => {
 
       return notifyClient.sendSms(templateId, phoneNo, options)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -236,7 +236,7 @@ describe('notification api', () => {
 
       return notifyClient.sendSms(templateId, phoneNo, options)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -277,7 +277,7 @@ describe('notification api', () => {
 
       return notifyClient.sendLetter(templateId, options)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -306,7 +306,7 @@ describe('notification api', () => {
 
     return notifyClient.getNotificationById(notificationId)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
   });
 
@@ -339,7 +339,7 @@ describe('notification api', () => {
 
       return notifyClient.sendPrecompiledLetter(reference, pdf_file)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -356,7 +356,7 @@ describe('notification api', () => {
 
       return notifyClient.sendPrecompiledLetter(reference, pdf_file, postage)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -380,7 +380,7 @@ describe('notification api', () => {
 
       return notifyClient.getNotifications()
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -394,7 +394,7 @@ describe('notification api', () => {
 
       return notifyClient.getNotifications(undefined, undefined, reference)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -408,7 +408,7 @@ describe('notification api', () => {
 
       return notifyClient.getNotifications(undefined, 'failed')
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -423,7 +423,7 @@ describe('notification api', () => {
 
       return notifyClient.getNotifications(templateType, status)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -439,7 +439,7 @@ describe('notification api', () => {
 
       return notifyClient.getNotifications(templateType, status, reference)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
 
@@ -460,7 +460,7 @@ describe('notification api', () => {
 
       return notifyClient.getNotifications(templateType, status, reference, olderThanId)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
     });
   });
@@ -477,7 +477,7 @@ describe('notification api', () => {
 
       return notifyClient.getTemplateById(templateId)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
 
     });
@@ -493,7 +493,7 @@ describe('notification api', () => {
 
       return notifyClient.getTemplateByIdAndVersion(templateId, version)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
 
     });
@@ -506,7 +506,7 @@ describe('notification api', () => {
 
       return notifyClient.getAllTemplates()
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
 
     });
@@ -521,7 +521,7 @@ describe('notification api', () => {
 
       return notifyClient.getAllTemplates(templateType)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
 
     });
@@ -538,7 +538,7 @@ describe('notification api', () => {
 
       return notifyClient.previewTemplateById(templateId, payload)
       .then(function (response) {
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
 
     });
@@ -553,7 +553,7 @@ describe('notification api', () => {
 
       return notifyClient.previewTemplateById(templateId)
       .then(function (response) {
-        expect(response .statusCode).to.equal(200);
+        expect(response .status).to.equal(200);
       });
     });
   });
@@ -566,7 +566,7 @@ describe('notification api', () => {
 
     return notifyClient.getReceivedTexts()
       .then(function(response){
-        expect(response.statusCode).to.equal(200);
+        expect(response.status).to.equal(200);
       });
   });
 
@@ -580,7 +580,7 @@ describe('notification api', () => {
 
     return notifyClient.getReceivedTexts(olderThanId)
     .then(function(response){
-      expect(response.statusCode).to.equal(200);
+      expect(response.status).to.equal(200);
     });
   });
 });


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->
Requests has been deprecated and so we replace it with a more modern
library. This will mean some small breaking changes for users which are
noted by the version bump and changelog records.

Also fixes the `User-agent` header to be `User-Agent` as per the
docs:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent

## How to review
- Please review line by line for a general code review
- Have a think if there is anything missing from the changelog or ways we could improve the experience for developers upgrading
- Acknowledge the decision that the published docs will be out of date with older versions of the client (but that appears to be a pattern we already use)
- General thumbs up that assuming the code is all 'correct', this we still want to make this change as it will mean a major breaking change for our users

## Question
Our docs (https://docs.notifications.service.gov.uk/node.html#response) say that `If the request to the client is successful, the promise resolves with an object` and show properties on that object like `subject`, `body`, `date_created` etc. However, for a user to access this I think they instead need to look at `response.body` which we do not make clear. Is that correct? If so, then it also means that with this change they will instead need to look at `response.data` instead? If so, should our docs be making that clear that people need to look at that. I've never heard any comments from users about it before so maybe they don't have any trouble with it?

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`

