### PR TITLE
Update address fields to include line 7

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -434,7 +434,19 @@ The personalisation argument always contains the following parameters for the le
 
 - `address_line_1`
 - `address_line_2`
-- `postcode` (this needs to be a real UK postcode)
+– `address_line_3` 
+– `address_line_4` 
+– `address_line_5` 
+– `address_line_6`
+– `address_line_7`
+
+The address must have at least 3 lines.
+
+The last line needs to be a real UK postcode or the name of a country outside the UK.
+
+Notify checks for international addresses and will automatically charge you the correct postage.
+
+The `postcode` personalisation argument has been replaced. If your template still uses `postcode`, Notify will treat it as the last line of the address.
 
 Any other placeholder fields included in the letter template also count as required parameters. You must provide their values in an `object`. For example:
 
@@ -443,23 +455,8 @@ Any other placeholder fields included in the letter template also count as requi
   personalisation: {
     'address_line_1': 'The Occupier',
     'address_line_2': '123 High Street',
-    'postcode': 'SW14 6BH',
+    'address_line_3': 'SW14 6BH',
     'application_date': '2018-01-01'
-  }
-}
-```
-
-#### personalisation (optional)
-
-The following parameters in the letter recipient’s address are optional:
-
-```javascript
-{
-  personalisation: {
-    'address_line_3': 'Richmond upon Thames',
-    'address_line_4': 'London',
-    'address_line_5': 'Middlesex',
-    'address_line_6': 'UK'
   }
 }
 ```
@@ -500,15 +497,16 @@ If the request is not successful, the promise fails with an `err`.
 
 |err.error.status_code|err.error.errors|How to fix|
 |:--- |:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation address_line_1 is a required property"`<br>`}]`|Ensure that your template has a field for the first line of the address, refer to [personalisation](#send-a-letter-arguments-personalisation-required) for more information|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Must be a real UK postcode"`<br>`}]`|Ensure that the value for the postcode field in your letter is a real UK postcode|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
-|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
-|`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](#rate-limits) for more information|
-|`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number|
-|`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys).|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode).|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation address_line_1 is a required property"`<br>`}]`|Ensure that your template has a field for the first line of the address, refer to [personalisation](#send-a-letter-arguments-personalisation-required) for more information.|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Must be a real UK postcode"`<br>`}]`|Ensure that the value for the last line of the address is a real UK postcode.|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Last line of address must be a real UK postcode or another country"`<br>`}]`|Ensure that the value for the last line of the address is a real UK postcode or the name of a country outside the UK.|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock.|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information.|
+|`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](#rate-limits) for more information.|
+|`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#daily-limits) for the limit number.|
+|`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
 
 ## Send a precompiled letter
@@ -669,7 +667,7 @@ If the request to the client is successful, the promise resolves with an `object
   'line_4': 'Some Town',
   'line_5': 'Some county',
   'line_6': 'Something else',
-  'postcode': 'postcode',
+  'line_7': 'UK postcode or country',
   'postage': 'first or second',
   'type': 'sms|letter|email',
   'status': 'current status',


### PR DESCRIPTION
The client documentation talks about address lines 1-6 and postcode (including mandatory nature of address lines 1,2 and postcode). Now that we are supporting address lines 1-7 we need to update the documentation to reflect this.

There is a question about what we should say in the docs about the mapping that we do from postcode, or that it is sort of degraded, but needs a bit of a thought for that.

After we have done this story, services will see the new address personalisation that we require and understand that it won’t be a breaking change for them.