### PR TITLE
Fix disabling confirm email step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.1 - 2023-07-13
+
+* Fix a bug with default behaviour for `confirmEmailBeforeDownload`, which coalesced false to null.
+
 ## 7.0.0 - 2023-01-12
 
 * Remove support for node versions below v14.17.3.

--- a/client/notification.js
+++ b/client/notification.js
@@ -368,7 +368,7 @@ Object.assign(NotifyClient.prototype, {
           data.is_csv = options.isCsv;
         }
 
-        data.confirm_email_before_download = options.confirmEmailBeforeDownload || null;
+        data.confirm_email_before_download = options.confirmEmailBeforeDownload !== undefined ? options.confirmEmailBeforeDownload : null;
         data.retention_period = options.retentionPeriod || null
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "repository": {
     "type": "git",

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -228,6 +228,13 @@ describe('notification api', () => {
       ).contains({is_csv: false, confirm_email_before_download: null, retention_period: null})
     });
 
+    it('should allow send a file email confirmation to be disabled', () => {
+      let file = Buffer.alloc(2*1024*1024)
+      expect(
+        notifyClient.prepareUpload(file, {confirmEmailBeforeDownload: false})
+      ).contains({is_csv: false, confirm_email_before_download: false, retention_period: null})
+    });
+
     it('should allow send a file email confirmation to be set', () => {
       let file = Buffer.alloc(2*1024*1024)
       expect(


### PR DESCRIPTION
There is a bug that coalesces false to null, which ends up applying the default action of enabling email confirmation (by the API)

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
