### PR TITLE
fix assignment to undeclared variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.5 - 2023-11-13
+
+* Fix a few cases of assignment to undeclared (global) variables
+
 ## 7.0.4 - 2023-11-10
 
 * Bump axios to the 1.x branch to address CVE-2023-45857. Due to underlying changes in Axios you may have to explicitly set the `protocol` property when constructing your `proxyConfig` object, if using a proxy.

--- a/client/notification.js
+++ b/client/notification.js
@@ -201,8 +201,8 @@ Object.assign(NotifyClient.prototype, {
 
   sendPrecompiledLetter: function(reference, pdf_file, postage) {
     var postage = postage || undefined
-    content = _check_and_encode_file(pdf_file, 5)
-    notification = {
+    var content = _check_and_encode_file(pdf_file, 5)
+    var notification = {
       "reference": reference,
       "content": content
     }
@@ -327,6 +327,8 @@ Object.assign(NotifyClient.prototype, {
   * @returns {Promise}
   */
   getReceivedTexts: function(olderThan){
+    let queryString;
+
     if (olderThan) {
       queryString = '?older_than=' + olderThan;
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What problem does the pull request solve?
I found line 204 threw a type error ('content is not defined') when using this library as a dependency in a Typescript project, in strict mode, in combination with esbuild bundling. Esbuild [respects the 'alwaysStrict' setting](https://esbuild.github.io/content-types/#tsconfig-json) in a local tsconfig, and so a 'use strict;' directive is inserted which affects all code in the bundle. [Assigning to an undeclared variable](https://www.w3schools.com/js/js_strict.asp) is an error when the directive is in place.

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
