### PR TITLE
Fix version number in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.0.3 - 2023-07-21
+## 7.0.4 - 2023-11-10
 
 * Bump axios to the 1.x branch to address CVE-2023-45857. Due to underlying changes in Axios you may have to explicitly set the `protocol` property when constructing your `proxyConfig` object, if using a proxy.
 


### PR DESCRIPTION
Copy paste oops

Latest version (today) is:
https://github.com/alphagov/notifications-node-client/blob/0057c823f7de0c155313781f62af5316c6354b3a/package.json#L3