### PR TITLE
Bump Axios to version 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.6 - 2023-11-13
+
+* Bump axios from 1.2.6 to 1.6.1
+
 ## 7.0.5 - 2023-11-13
 
 * Fix a few cases of assignment to undeclared (global) variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.0.4",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.2.0",
+        "axios": "^1.6.1",
         "jsonwebtoken": "^9.0.0"
       },
       "devDependencies": {
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.6.tgz",
-      "integrity": "sha512-rC/7F08XxZwjMV4iuWv+JpD3E0Ksqg9nac4IIg6RwNuF0JTeWoCo/mBNG54+tNhhI11G3/VDRbdDQTs9hGp4pQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5664,9 +5664,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.6.tgz",
-      "integrity": "sha512-rC/7F08XxZwjMV4iuWv+JpD3E0Ksqg9nac4IIg6RwNuF0JTeWoCo/mBNG54+tNhhI11G3/VDRbdDQTs9hGp4pQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "jsonwebtoken": "^9.0.0",
-    "axios": "^1.2.0"
+    "axios": "^1.6.1"
   },
   "devDependencies": {
     "chai": "4.1.2",


### PR DESCRIPTION
This pulls in the latest version of Axios which has some security vulnerabilities fixed.

I asked on GDS Slack whether we should be specifying the oldest compatible version of the dependency or the latest version.

This is the response I got:
> I would specify the latest version that has the vulnerability patched.
>
> If you think that might result in a breaking change for your consumers, I'd then make a new major version of your package,
> describing the potential for breaking changes.
>
> Version numbers are cheap, so you should feel free to make as many of them as possible.

***

Fixes #187

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ]`DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
