### PR TITLE
Allow setting custom filenames for documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 8.0.0 - 2023-12-27
+
+* Remove the default `is_csv` boolean parameter from `prepareUpload`. This method now accepts a file and an options map with the following options. For more specific information please read the documentation.
+    * `filename` (string) - specify the document's filename upon download
+    * `confirm_email_before_download` (boolean) - require the user to enter their email address before the file can be downloaded.
+    * `retention_period` (string) - how long Notify should make the file available to the user for.
+
 ## 7.0.6 - 2023-11-13
 
 * Bump axios from 1.2.6 to 1.6.1

--- a/client/notification.js
+++ b/client/notification.js
@@ -356,26 +356,18 @@ Object.assign(NotifyClient.prototype, {
   prepareUpload: function(fileData, options) {
     let data = {
       file: _check_and_encode_file(fileData, 2),
-      is_csv: false,
+      filename: null,
       confirm_email_before_download: null,
       retention_period: null,
     }
 
     if (options !== undefined) {
-      if (typeof(options) === 'boolean') {
-        data.is_csv = options
-      }
-      else {
-        if (options.isCsv !== undefined) {
-          data.is_csv = options.isCsv;
-        }
-
-        data.confirm_email_before_download = options.confirmEmailBeforeDownload !== undefined ? options.confirmEmailBeforeDownload : null;
-        data.retention_period = options.retentionPeriod || null
-      }
+      data.filename = options.filename || null;
+      data.confirm_email_before_download = options.confirmEmailBeforeDownload !== undefined ? options.confirmEmailBeforeDownload : null;
+      data.retention_period = options.retentionPeriod || null;
     }
 
-    return data
+    return data;
   },
 
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notifications-node-client",
-  "version": "7.0.4",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notifications-node-client",
-      "version": "7.0.4",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notifications-node-client",
-  "version": "7.0.6",
+  "version": "8.0.0",
   "homepage": "https://docs.notifications.service.gov.uk/node.html",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update client for the new document download feature which allows specifying a download filename for files sent by email.

This supercedes the old `isCsv` parameter that was inconsistent at best.

Given this, we are dropping support for `isCsv` altogether which lets us clean up the interface for the `prepareUpload` function to now only use the new options dict.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `DOCUMENTATION.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [x] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
