### PR TITLE
replace jsonwebtoken with jose

### DIFF
--- a/client/api_client.js
+++ b/client/api_client.js
@@ -49,7 +49,7 @@ function ApiClient() {
  * @param {string} apiKeyId
  * @param {string} serviceId
  *
- * @returns {string}
+ * @returns {Promise<string>}
  */
 function createToken(requestMethod, requestPath, apiKeyId, serviceId) {
   return createGovukNotifyToken(requestMethod, requestPath, apiKeyId, serviceId);
@@ -64,18 +64,21 @@ Object.assign(ApiClient.prototype, {
    * @returns {Promise}
    */
   get: function(path, additionalOptions) {
-    var options = {
-      method: 'get',
-      url: this.urlBase + path,
-      headers: {
-        'Authorization': 'Bearer ' + createToken('GET', path, this.apiKeyId, this.serviceId),
-        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
-      }
-    };
-    Object.assign(options, additionalOptions)
-    if(this.proxy !== null) options.proxy = this.proxy;
+    return createToken('GET', path, this.apiKeyId, this.serviceId)
+      .then((token) => {
+        var options = {
+          method: 'get',
+          url: this.urlBase + path,
+          headers: {
+            'Authorization': 'Bearer ' + token,
+            'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
+          }
+        };
+        Object.assign(options, additionalOptions)
+        if(this.proxy !== null) options.proxy = this.proxy;
 
-    return restClient(options);
+        return restClient(options);
+      })
   },
 
   /**
@@ -86,19 +89,22 @@ Object.assign(ApiClient.prototype, {
    * @returns {Promise}
    */
   post: function(path, data){
-    var options = {
-      method: 'post',
-      url: this.urlBase + path,
-      data: data,
-      headers: {
-        'Authorization': 'Bearer ' + createToken('GET', path, this.apiKeyId, this.serviceId),
-        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
-      }
-    };
+    return createToken('GET', path, this.apiKeyId, this.serviceId)
+      .then((token) => {
+        var options = {
+          method: 'post',
+          url: this.urlBase + path,
+          data: data,
+          headers: {
+            'Authorization': 'Bearer ' + token,
+            'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
+          }
+        };
 
-    if(this.proxy !== null) options.proxy = this.proxy;
+        if(this.proxy !== null) options.proxy = this.proxy;
 
-    return restClient(options);
+        return restClient(options);
+      })
   },
 
   /**

--- a/client/authentication.js
+++ b/client/authentication.js
@@ -1,18 +1,12 @@
-var jwt = require('jsonwebtoken');
+var jose = require('jose')
 
 
 function createGovukNotifyToken(request_method, request_path, secret, client_id) {
-
-  return jwt.sign(
-    {
-      iss: client_id,
-      iat: Math.round(Date.now() / 1000)
-    },
-    secret,
-    {
-      header: {typ: "JWT", alg: "HS256"}
-    }
-  );
+  return new jose.SignJWT()
+    .setIssuer(client_id)
+    .setIssuedAt()
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .sign(new TextEncoder().encode(secret));
 }
 
 module.exports = createGovukNotifyToken;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.1",
-        "jsonwebtoken": "^9.0.0"
+        "jose": "^5.2.0"
       },
       "devDependencies": {
         "chai": "4.1.2",
@@ -485,11 +485,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
@@ -1152,14 +1147,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -2837,6 +2824,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jose": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -2895,35 +2890,6 @@
         "node": "*"
       }
     },
-    "node_modules/jsonwebtoken": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash": "^4.17.21",
-        "ms": "^2.1.1",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -2935,25 +2901,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -3018,7 +2965,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
@@ -3054,17 +3002,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/map-cache": {
@@ -3511,7 +3448,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.7",
@@ -4372,6 +4310,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5383,11 +5322,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -5837,11 +5771,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -6356,14 +6285,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "emoji-regex": {
@@ -7642,6 +7563,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "jose": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
+      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -7694,27 +7620,6 @@
       "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
       "dev": true
     },
-    "jsonwebtoken": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-      "requires": {
-        "jws": "^3.2.2",
-        "lodash": "^4.17.21",
-        "ms": "^2.1.1",
-        "semver": "^7.3.8"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
     "jsx-ast-utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -7723,25 +7628,6 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
-      }
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -7793,7 +7679,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -7823,14 +7710,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
       }
     },
     "map-cache": {
@@ -8154,7 +8033,8 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -8790,7 +8670,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -9598,11 +9479,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
   "author": "GDS developers",
   "license": "MIT",
   "dependencies": {
-    "jsonwebtoken": "^9.0.0",
-    "axios": "^1.6.1"
+    "axios": "^1.6.1",
+    "jose": "^5.2.0"
   },
   "devDependencies": {
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
-    "chai-json-schema": "1.5.0",
     "chai-bytes": "0.1.2",
+    "chai-json-schema": "1.5.0",
     "jsonschema": "1.2.4",
     "mocha": "10.1.0",
     "mockdate": "2.0.2",

--- a/spec/api_client.js
+++ b/spec/api_client.js
@@ -33,20 +33,23 @@ describe('api client', function () {
       new ApiClient('key_name' + ':' + serviceId + ':' + apiKeyId),
     ].forEach(function(client, index, clients) {
 
-      nock(urlBase, {
-        reqheaders: {
-          'Authorization': 'Bearer ' + createGovukNotifyToken('GET', path, apiKeyId, serviceId),
-          'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
-        }
-      })
-        .get(path)
-        .reply(200, body);
+      createGovukNotifyToken('GET', path, apiKeyId, serviceId)
+        .then((token) => {
+          nock(urlBase, {
+            reqheaders: {
+              'Authorization': 'Bearer ' + token,
+              'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
+            }
+          })
+            .get(path)
+            .reply(200, body);
 
-      client.get(path)
-        .then(function (response) {
-          expect(response.data).to.deep.equal(body);
-          if (index == clients.length - 1) done();
-      });
+          client.get(path)
+            .then(function (response) {
+              expect(response.data).to.deep.equal(body);
+              if (index == clients.length - 1) done();
+          });
+        })
 
     });
 
@@ -55,29 +58,32 @@ describe('api client', function () {
   it('should make a post request with correct headers', function (done) {
 
     var urlBase = 'http://localhost',
-      path = '/email',
-      data = {
-        'data': 'qwjjs'
-      },
-      serviceId = 123,
-      apiKeyId = 'SECRET',
+        path = '/email',
+        data = {
+          'data': 'qwjjs'
+        },
+        serviceId = 123,
+        apiKeyId = 'SECRET',
+        apiClient = new ApiClient(urlBase, serviceId, apiKeyId);
+
+    createGovukNotifyToken('POST', path, apiKeyId, serviceId)
+      .then((token) => {
+      nock(urlBase, {
+        reqheaders: {
+          'Authorization': 'Bearer ' + token,
+          'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
+        }
+      })
+        .post(path, data)
+        .reply(200, {"hooray": "bkbbk"});
+
       apiClient = new ApiClient(urlBase, serviceId, apiKeyId);
-
-    nock(urlBase, {
-      reqheaders: {
-        'Authorization': 'Bearer ' + createGovukNotifyToken('POST', path, apiKeyId, serviceId),
-        'User-Agent': 'NOTIFY-API-NODE-CLIENT/' + version
-      }
-    })
-      .post(path, data)
-      .reply(200, {"hooray": "bkbbk"});
-
-    apiClient = new ApiClient(urlBase, serviceId, apiKeyId);
-    apiClient.post(path, data)
-      .then(function (response) {
-        expect(response.status).to.equal(200);
-        done();
-    });
+      apiClient.post(path, data)
+        .then(function (response) {
+          expect(response.status).to.equal(200);
+          done();
+      });
+      });
   });
 
   it('should direct get requests through the proxy when set', function (done) {

--- a/spec/authentication.js
+++ b/spec/authentication.js
@@ -1,6 +1,6 @@
 var expect = require('chai').expect,
     MockDate = require('mockdate'),
-    jwt = require('jsonwebtoken'),
+    jose = require('jose'),
     createGovukNotifyToken = require('../client/authentication.js');
 
 
@@ -16,14 +16,17 @@ describe('Authentication', function() {
 
   describe('tokens', function() {
 
-    it('can be generated and decoded', function() {
+    it('can be generated and decoded', function(done) {
 
-      var token = createGovukNotifyToken("POST", "/v2/notifications/sms", "SECRET", 123),
-          decoded = jwt.verify(token, 'SECRET');
+      createGovukNotifyToken("POST", "/v2/notifications/sms", "SECRET", 123)
+        .then((token) => {
 
-      expect(token).to.equal('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOjEyMywiaWF0IjoxMjM0NTY3ODkwfQ.18aBKSLffjbX_TLmosB_qYgW9EkWIQpBgWy7GpiKg6o');
-      expect(decoded.iss).to.equal(123);
-      expect(decoded.iat).to.equal(1234567890);
+          expect(token).to.equal('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOjEyMywiaWF0IjoxMjM0NTY3ODkwfQ.18aBKSLffjbX_TLmosB_qYgW9EkWIQpBgWy7GpiKg6o');
+          var decoded = jose.decodeJwt(token, 'SECRET');
+          expect(decoded.iss).to.equal(123);
+          expect(decoded.iat).to.equal(1234567890);
+          done();
+        });
 
     });
 

--- a/spec/notification.js
+++ b/spec/notification.js
@@ -20,10 +20,10 @@ function getNotifyClient() {
   return notifyClient;
 }
 
-function getNotifyAuthNock() {
+async function getNotifyAuthNock() {
   let notifyNock = nock(baseUrl, {
     reqheaders: {
-      'Authorization': 'Bearer ' + createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
+      'Authorization': 'Bearer ' + await createGovukNotifyToken('POST', '/v2/notifications/', apiKeyId, serviceId)
     }
   })
   return notifyNock;
@@ -31,16 +31,17 @@ function getNotifyAuthNock() {
 
 describe('notification api', () => {
 
-  beforeEach(() => {
+  let notifyClient = getNotifyClient();
+  let notifyAuthNock;
+
+  before(async () => {
     MockDate.set(1234567890000);
+    notifyAuthNock = await getNotifyAuthNock();
   });
 
-  afterEach(() => {
+  after(() => {
     MockDate.reset();
   });
-
-  let notifyClient = getNotifyClient();
-  let notifyAuthNock = getNotifyAuthNock();
 
   describe('sendEmail', () => {
     it('should send an email', () => {


### PR DESCRIPTION
This replaces jsonwebtoken with jose, which works natively in non-Node.js javascript runtimes such as Deno or Bun, whilst also reducing the number of transient dependencies.

Best to be paired with an update to package.json > engines.node to >=v18.12.0