### PR TITLE
Make the integration tests compatible with the dev environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,12 @@ RUN \
 	echo "Install base packages" \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		awscli \
 		make \
 		gnupg \
+		jq \
 	&& echo "Clean up" \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*
 
 WORKDIR /var/project
+COPY . .

--- a/spec/integration/test.js
+++ b/spec/integration/test.js
@@ -27,7 +27,7 @@ function make_random_id() {
 
 describer('notification api with a live service', function () {
   // default is 2000 (ms) - api is sometimes slower than this :(
-  this.timeout(40000)
+  this.timeout(120000)
 
   let notifyClient;
   let teamNotifyClient;
@@ -247,7 +247,7 @@ describer('notification api with a live service', function () {
           }
           if (err.response.data && (err.response.data.errors[0].error === "PDFNotReadyError")) {
             count += 1
-            if (count < 7) {
+            if (count < 24) {
               setTimeout(tryClient, 5000)
             } else {
               done(new Error('Too many PDFNotReadyError errors'));


### PR DESCRIPTION
[Trello card](https://trello.com/c/D1m5uleD/952-run-api-client-integration-tests-as-part-of-new-pipeline)

Some small updates to make the integration tests runnable in the dev environments via the new deploy pipeline.

[Tested in dev-a](https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/162) (5 times in a row to check for flakiness)