### PR TITLE
Add min-release-age=7 npm config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
This tells NPM to reject any package version published less than 7 days ago.

Part of the recommendation from the last round of npm supply chain attack.

Matches [admin config](https://github.com/alphagov/notifications-admin/blob/main/.npmrc)

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_node.md)
  - `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - `package.json`
- [ ] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`

This doesn't change the actual codebase, or what is published as the NPM package so I didn't bump the version.

