### PR TITLE
Allow additional attributes in schemas

### DIFF
--- a/spec/integration/schemas/v1/GET_notifications_return.json
+++ b/spec/integration/schemas/v1/GET_notifications_return.json
@@ -25,12 +25,12 @@
           "type" : "string"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "page_size": {"type": "number"},
     "total": {"type": "number"}
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "notifications", "links", "page_size", "total"
   ]

--- a/spec/integration/schemas/v1/POST_notification_return_email.json
+++ b/spec/integration/schemas/v1/POST_notification_return_email.json
@@ -11,17 +11,17 @@
           "properties": {
             "id": {"$ref": "definitions.json#/uuid"}
           },
-          "additionalProperties": false,
+          "additionalProperties": true,
           "required": ["id"]
         },
         "body": {"type": "string"},
         "template_version": {"type": "number"},
         "subject": {"type": "string"}
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": ["notification", "body", "template_version", "subject"]
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["data"]
 }

--- a/spec/integration/schemas/v1/POST_notification_return_sms.json
+++ b/spec/integration/schemas/v1/POST_notification_return_sms.json
@@ -11,16 +11,16 @@
           "properties": {
             "id": {"$ref": "definitions.json#/uuid"}
           },
-          "additionalProperties": false,
+          "additionalProperties": true,
           "required": ["id"]
         },
         "body": {"type": "string"},
         "template_version": {"type": "number"}
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": ["notification", "body", "template_version"]
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["data"]
 }

--- a/spec/integration/schemas/v1/email_notification.json
+++ b/spec/integration/schemas/v1/email_notification.json
@@ -55,7 +55,7 @@
         },
         "version": {"type": "number"}
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": ["id", "name", "template_type", "version"]
     },
     "service": {"$ref": "definitions.json#/uuid"},
@@ -67,7 +67,7 @@
             "id": {"$ref": "definitions.json#/uuid"},
             "original_file_name": {"type": "string"}
           },
-          "additionalProperties": false,
+          "additionalProperties": true,
           "required": ["id", "original_file_name"]
         },
         {"type": "null"}
@@ -81,7 +81,7 @@
     "content_char_count": {"type": "null"},
     "subject": {"type": "string"}
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "id",
     "to",

--- a/spec/integration/schemas/v1/sms_notification.json
+++ b/spec/integration/schemas/v1/sms_notification.json
@@ -55,7 +55,7 @@
         },
         "version": {"type": "number"}
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": ["id", "name", "template_type", "version"]
     },
     "service": {"$ref": "definitions.json#/uuid"},
@@ -67,7 +67,7 @@
             "id": {"$ref": "definitions.json#/uuid"},
             "original_file_name": {"type": "string"}
           },
-          "additionalProperties": false,
+          "additionalProperties": true,
           "required": ["id", "original_file_name"]
         },
         {"type": "null"}
@@ -80,7 +80,7 @@
     "body": {"type": "string"},
     "content_char_count": {"type": "number"}
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "id",
     "to",

--- a/spec/integration/schemas/v2/GET_notifications_response.json
+++ b/spec/integration/schemas/v2/GET_notifications_response.json
@@ -20,10 +20,10 @@
                     "type": "string"
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["current"]
         }
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "required": ["notifications", "links"]
 }

--- a/spec/integration/schemas/v2/GET_received_text_response.json
+++ b/spec/integration/schemas/v2/GET_received_text_response.json
@@ -19,5 +19,5 @@
         "id", "user_number", "created_at", "service_id",
         "notify_number", "content"
     ],
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/spec/integration/schemas/v2/GET_received_texts_response.json
+++ b/spec/integration/schemas/v2/GET_received_texts_response.json
@@ -20,10 +20,10 @@
                     "type": "string"
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "required": ["current"]
         }
     },
     "required": ["received_text_messages", "links"],
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/spec/integration/schemas/v2/POST_notification_email_response.json
+++ b/spec/integration/schemas/v2/POST_notification_email_response.json
@@ -13,6 +13,6 @@
         {"type": "null"}
       ]}
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["id", "content", "uri", "template"]
 }

--- a/spec/integration/schemas/v2/POST_notification_letter_response.json
+++ b/spec/integration/schemas/v2/POST_notification_letter_response.json
@@ -14,6 +14,6 @@
           {"type": "null"}
         ]}
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "required": ["id", "content", "uri", "template"]
   }

--- a/spec/integration/schemas/v2/POST_notification_precompiled_letter_response.json
+++ b/spec/integration/schemas/v2/POST_notification_precompiled_letter_response.json
@@ -14,6 +14,6 @@
           {"type": "null"}
         ]}
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "required": ["id", "postage"]
   }

--- a/spec/integration/schemas/v2/POST_notification_sms_response.json
+++ b/spec/integration/schemas/v2/POST_notification_sms_response.json
@@ -13,6 +13,6 @@
         {"type": "null"}
       ]}
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": ["id", "content", "uri", "template"]
 }


### PR DESCRIPTION
Node client library has been an outlier, compared to other Notify client libraries. It required all attributes to be included in its schemas.

If an attribute was passed in a response that was not expected, tests would fail.

This makes it more tricky to deploy changes that add attributes to our public API. As you have to first update the node client, before making changes to our api app.

Since this is an outlier behaviour, can trip people up, and is not necessary, this commit changes it, so that additional attributes are allowed.

Since this change only affects the tests, that are mainly used by our system, not by our users, as far as I understand there is no need for releasing new version.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ N/A] I’ve written unit tests for these changes
- [ N/A] I’ve updated the documentation in
  - [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_node.md)
  - `CHANGELOG.md`
- [ N/A] I’ve bumped the version number in
  - `package.json`
- [N/A] I've added new environment variables in
  - `CONTRIBUTING.md`
  - `notifications-node-client/scripts/generate_docker_env.sh`
